### PR TITLE
MODIFY: 수정 사항 반영 및 주문 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
+++ b/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
@@ -33,4 +33,5 @@ public class EndPoint {
     public static final String STORE = "/store";
     public static final String ORDER_COUNT = ORDER +"/count";
     public static final String ORDER_LIST = ORDER + "/list";
+    public static final String ORDER_CHECK = ORDER + "/check";
 }

--- a/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
+++ b/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
@@ -29,4 +29,7 @@ public class EndPoint {
     public static final String CANCEL = "/cancel";
     public static final String REDIRECT_SUCCESS = REDIRECT + "/success";
     public static final String REDIRECT_FAIL = REDIRECT + "/fail";
+
+    public static final String STORE = "/store";
+    public static final String ORDER_COUNT = ORDER +"/count";
 }

--- a/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
+++ b/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
@@ -32,4 +32,5 @@ public class EndPoint {
 
     public static final String STORE = "/store";
     public static final String ORDER_COUNT = ORDER +"/count";
+    public static final String ORDER_LIST = ORDER + "/list";
 }

--- a/src/main/java/com/rabbit/dayfilm/order/dto/OrderCreateReqDto.java
+++ b/src/main/java/com/rabbit/dayfilm/order/dto/OrderCreateReqDto.java
@@ -15,12 +15,10 @@ import java.util.List;
 @NoArgsConstructor
 public class OrderCreateReqDto {
     @JsonCreator
-    public OrderCreateReqDto(Long userId, List<Long> basketIds, String payMethod, DeliveryMethod deliveryMethod,
-                             Long addressId, String shipmentRequired) {
+    public OrderCreateReqDto(Long userId, List<Long> basketIds, String payMethod, Long addressId, String shipmentRequired) {
         this.userId = userId;
         this.basketIds = basketIds;
         this.payMethod = Method.fromString(payMethod);
-        this.deliveryMethod = deliveryMethod;
         this.addressId = addressId;
         this.shipmentRequired = shipmentRequired;
     }
@@ -30,8 +28,6 @@ public class OrderCreateReqDto {
     private List<Long> basketIds;
     @ApiModelProperty(value="토스 결제 수단", example="카드", required = true)
     private Method payMethod;
-    @ApiModelProperty(value = "배송 수단", example = "PARCEL", required = true)
-    private DeliveryMethod deliveryMethod;
     @ApiModelProperty(value="회원 주소 목록의 번호", example="1", required = true)
     private Long addressId;
     @ApiModelProperty(value = "배송 요구사항", example="부재 시 문 앞에 놔주세요.")

--- a/src/main/java/com/rabbit/dayfilm/order/entity/DeliveryCode.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/DeliveryCode.java
@@ -1,0 +1,17 @@
+package com.rabbit.dayfilm.order.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum DeliveryCode {
+    LOTTE("롯데 택배");
+
+    /**
+     * 포맷 미정 (택배사 API 결정 후 작성 예정)
+     */
+
+    private String title;
+
+}

--- a/src/main/java/com/rabbit/dayfilm/order/entity/Order.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/Order.java
@@ -5,6 +5,7 @@ import com.rabbit.dayfilm.store.entity.Address;
 import lombok.*;
 
 import javax.persistence.*;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -40,6 +41,9 @@ public class Order {
     @Column(name = "ended", nullable = false)
     private LocalDateTime ended;
 
+    @Column(name = "outgoing_date")
+    private LocalDate outgoingDate;
+
     @Column(name = "method", nullable = false)
     @Enumerated(EnumType.STRING)
     private DeliveryMethod method;
@@ -59,5 +63,8 @@ public class Order {
 
     public void updateStatus(OrderStatus status) {
         this.status = status;
+    }
+    public void updateOutgoingDate(LocalDate outgoingDate) {
+        this.outgoingDate = outgoingDate;
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/order/entity/Order.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/Order.java
@@ -54,6 +54,9 @@ public class Order {
     @Column(name ="price", nullable = false)
     private Integer price;
 
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private OrderDelivery delivery;
+
     public void updateStatus(OrderStatus status) {
         this.status = status;
     }

--- a/src/main/java/com/rabbit/dayfilm/order/entity/OrderDelivery.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/OrderDelivery.java
@@ -1,0 +1,20 @@
+package com.rabbit.dayfilm.order.entity;
+
+import javax.persistence.*;
+
+@Entity
+public class OrderDelivery {
+    @Id @GeneratedValue
+    @Column(name = "delivery_id")
+    private Long id;
+
+    @OneToOne(mappedBy = "delivery", fetch = FetchType.LAZY)
+    private Order order;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "code", nullable = false)
+    private DeliveryCode code;
+
+    @Column(name = "tracking_number", nullable = false)
+    private String trackingNumber;
+}

--- a/src/main/java/com/rabbit/dayfilm/order/entity/OrderStatus.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/OrderStatus.java
@@ -4,9 +4,8 @@ public enum OrderStatus {
     //주문접수
     PAY_WAITING,
     PAY_DONE,
-    VISIT_WAIT,
-    DELIVERY_WAIT,
 
+    RECEIVE_WAIT,
     //발송진행
     DELIVERY,
 

--- a/src/main/java/com/rabbit/dayfilm/order/entity/OrderStatus.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/OrderStatus.java
@@ -12,8 +12,12 @@ public enum OrderStatus {
 
     //발송완료
     RENTAL,
-    FINISH,
+    RETURN,
+    RETURN_DELIVERY,
 
     //환불
-    CANCEL
+    CANCEL,
+
+    //사용 완료
+    DONE
 }

--- a/src/main/java/com/rabbit/dayfilm/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/order/service/OrderServiceImpl.java
@@ -107,7 +107,7 @@ public class OrderServiceImpl implements OrderService {
                             .started(basket.getStarted())
                             .ended(basket.getEnded())
                             .address(address)
-                            .method(request.getDeliveryMethod())
+                            .method(basket.getMethod())
                             .shipmentRequired(request.getShipmentRequired())
                             .price(price)
                             .build()

--- a/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
+++ b/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
@@ -2,14 +2,14 @@ package com.rabbit.dayfilm.store.controller;
 
 import com.rabbit.dayfilm.common.EndPoint;
 import com.rabbit.dayfilm.store.dto.OrderCountResDto;
+import com.rabbit.dayfilm.store.dto.OrderListCond;
+import com.rabbit.dayfilm.store.dto.OrderListInStoreResDto;
 import com.rabbit.dayfilm.store.service.StoreService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,5 +21,12 @@ public class StoreController {
     @Operation(summary = "판매자 주문 수", description = "주문조회 및 배송관리 상단의 결제완료,배송 진행,배송 완료 건수를 반환합니다.")
     public ResponseEntity<OrderCountResDto> getOrderCount(@RequestParam("storeId") Long id) {
         return ResponseEntity.ok().body(storeService.getOrderCount(id));
+    }
+
+
+    @GetMapping(EndPoint.ORDER_LIST)
+    @Operation(summary = "주문 목록 조회", description = "파라미터로 보내는 상태, 수령 방법 등에 따라서 동적인 검색 결과를 반환.")
+    public ResponseEntity<OrderListInStoreResDto> getOrderList(@ModelAttribute OrderListCond condition, Pageable pageable) {
+        return ResponseEntity.ok(storeService.getOrderList(condition, pageable));
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
+++ b/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
@@ -1,0 +1,25 @@
+package com.rabbit.dayfilm.store.controller;
+
+import com.rabbit.dayfilm.common.EndPoint;
+import com.rabbit.dayfilm.store.dto.OrderCountResDto;
+import com.rabbit.dayfilm.store.service.StoreService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(EndPoint.STORE)
+public class StoreController {
+    private final StoreService storeService;
+
+    @GetMapping(EndPoint.ORDER_COUNT)
+    @Operation(summary = "판매자 주문 수", description = "주문조회 및 배송관리 상단의 결제완료,배송 진행,배송 완료 건수를 반환합니다.")
+    public ResponseEntity<OrderCountResDto> getOrderCount(@RequestParam("storeId") Long id) {
+        return ResponseEntity.ok().body(storeService.getOrderCount(id));
+    }
+}

--- a/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
+++ b/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
@@ -1,6 +1,9 @@
 package com.rabbit.dayfilm.store.controller;
 
+import com.rabbit.dayfilm.common.CodeSet;
 import com.rabbit.dayfilm.common.EndPoint;
+import com.rabbit.dayfilm.common.response.SuccessResponse;
+import com.rabbit.dayfilm.store.dto.OrderCheckDto;
 import com.rabbit.dayfilm.store.dto.OrderCountResDto;
 import com.rabbit.dayfilm.store.dto.OrderListCond;
 import com.rabbit.dayfilm.store.dto.OrderListInStoreResDto;
@@ -10,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,5 +33,11 @@ public class StoreController {
     @Operation(summary = "주문 목록 조회", description = "파라미터로 보내는 상태, 수령 방법 등에 따라서 동적인 검색 결과를 반환.")
     public ResponseEntity<OrderListInStoreResDto> getOrderList(@ModelAttribute OrderListCond condition, Pageable pageable) {
         return ResponseEntity.ok(storeService.getOrderList(condition, pageable));
+    }
+
+    @PostMapping(EndPoint.ORDER_CHECK)
+    @Operation(summary = "주문 확인(출고일 지정)", description = "해당 주문의 출고일을 지정합니다.\n출고일이 지정된 주문 내용을 반환합니다.")
+    public ResponseEntity<List<OrderCheckDto>> checkOrders(@RequestBody List<OrderCheckDto> request) {
+        return ResponseEntity.ok().body(storeService.checkOrders(request));
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/store/dto/OrderCheckDto.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/OrderCheckDto.java
@@ -1,0 +1,14 @@
+package com.rabbit.dayfilm.store.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class OrderCheckDto {
+    @ApiModelProperty(value="주문 PK(!= orderId)", example="1", required = true)
+    private Long orderPk;
+    @ApiModelProperty(value="출고 예정일", example="2023-03-30", required = true)
+    private LocalDate outgoingDate;
+}

--- a/src/main/java/com/rabbit/dayfilm/store/dto/OrderCountResDto.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/OrderCountResDto.java
@@ -1,0 +1,21 @@
+package com.rabbit.dayfilm.store.dto;
+
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+@Getter
+public class OrderCountResDto {
+    @ApiModelProperty(value="결제 완료 수", example="1")
+    private final Integer payDoneCount;
+    @ApiModelProperty(value="배송 진행", example="2")
+    private final Integer deliveryCount;
+    @ApiModelProperty(value="렌탈 중(배송완료)", example="1")
+    private final Integer rentalCount;
+
+    public OrderCountResDto(Integer payDoneCount, Integer deliveryCount, Integer rentalCount) {
+        this.payDoneCount = payDoneCount;
+        this.deliveryCount = deliveryCount;
+        this.rentalCount = rentalCount;
+    }
+}

--- a/src/main/java/com/rabbit/dayfilm/store/dto/OrderListCond.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/OrderListCond.java
@@ -1,0 +1,18 @@
+package com.rabbit.dayfilm.store.dto;
+
+import com.rabbit.dayfilm.item.entity.DeliveryMethod;
+import com.rabbit.dayfilm.order.entity.OrderStatus;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OrderListCond {
+    @ApiModelProperty(value="가게 번호", example="4")
+    private Long storeId;
+    @ApiModelProperty(value="주문 상태", example="DELIVERY")
+    private OrderStatus status;
+    @ApiModelProperty(value="배송 방법", example="PARCEL")
+    private DeliveryMethod method;
+}

--- a/src/main/java/com/rabbit/dayfilm/store/dto/OrderListInStoreResDto.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/OrderListInStoreResDto.java
@@ -1,0 +1,54 @@
+package com.rabbit.dayfilm.store.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.rabbit.dayfilm.order.entity.DeliveryCode;
+import com.rabbit.dayfilm.order.entity.OrderStatus;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class OrderListInStoreResDto {
+    @ApiModelProperty(value="주문 목록", example="[{}]")
+    private List<OrderList> orderList;
+    @ApiModelProperty(value="전체 페이지 수", example="15")
+    private Integer totalPage;
+    @ApiModelProperty(value="마지막 페이지 여부", example="true")
+    private Boolean isLast;
+
+    @Getter
+    public static class OrderList {
+        @ApiModelProperty(value="주문 PK(상태 업데이트할 때 넘겨야 할 파라미터)", example="15")
+        private Long id;
+        @ApiModelProperty(value="주문 상태", example="PAY_DONE")
+        private OrderStatus status;
+        @ApiModelProperty(value="주문 번호(여러 상품을 한 번에 주문하면 타 상품과 중복 가능)", example="202303023971983")
+        private String orderId;
+        @ApiModelProperty(value="상품 이름", example="캐논 카메라")
+        private String title;
+        @ApiModelProperty(value="주문자 닉네", example="박찬호")
+        private String name;
+        @ApiModelProperty(value="가격", example="2500")
+        private Integer price;
+        @ApiModelProperty(value="택배사", example="${미정}")
+        private String parcelCompany;
+        @ApiModelProperty(value="운송장 번호", example="234567")
+        private String trackingNumber;
+
+        @QueryProjection
+        public OrderList(Long id, OrderStatus status, String orderId, String title, String name,
+                         Integer price, DeliveryCode deliveryCode, String trackingNumber) {
+            this.id = id;
+            this.status = status;
+            this.orderId = orderId;
+            this.title = title;
+            this.name = name;
+            this.price = price;
+            this.parcelCompany = deliveryCode != null ? deliveryCode.getTitle() : null;
+            this.trackingNumber = trackingNumber;
+        }
+    }
+}

--- a/src/main/java/com/rabbit/dayfilm/store/dto/OrderListInStoreResDto.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/OrderListInStoreResDto.java
@@ -1,12 +1,14 @@
 package com.rabbit.dayfilm.store.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
+import com.rabbit.dayfilm.item.entity.DeliveryMethod;
 import com.rabbit.dayfilm.order.entity.DeliveryCode;
 import com.rabbit.dayfilm.order.entity.OrderStatus;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @AllArgsConstructor
@@ -29,7 +31,7 @@ public class OrderListInStoreResDto {
         private String orderId;
         @ApiModelProperty(value="상품 이름", example="캐논 카메라")
         private String title;
-        @ApiModelProperty(value="주문자 닉네", example="박찬호")
+        @ApiModelProperty(value="주문자 닉네임", example="박찬호")
         private String name;
         @ApiModelProperty(value="가격", example="2500")
         private Integer price;
@@ -37,10 +39,16 @@ public class OrderListInStoreResDto {
         private String parcelCompany;
         @ApiModelProperty(value="운송장 번호", example="234567")
         private String trackingNumber;
+        @ApiModelProperty(value="출고 예정일", example="2023-03-24")
+        private LocalDate outgoingDate;
+
+        @ApiModelProperty(value="수령 방법(PARCEL, VISIT)", example="PARCEL")
+        private DeliveryMethod deliveryMethod;
 
         @QueryProjection
         public OrderList(Long id, OrderStatus status, String orderId, String title, String name,
-                         Integer price, DeliveryCode deliveryCode, String trackingNumber) {
+                         Integer price, DeliveryCode deliveryCode, String trackingNumber,
+                         LocalDate outgoingDate, DeliveryMethod deliveryMethod) {
             this.id = id;
             this.status = status;
             this.orderId = orderId;
@@ -49,6 +57,8 @@ public class OrderListInStoreResDto {
             this.price = price;
             this.parcelCompany = deliveryCode != null ? deliveryCode.getTitle() : null;
             this.trackingNumber = trackingNumber;
+            this.outgoingDate = outgoingDate;
+            this.deliveryMethod = deliveryMethod;
         }
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/store/repository/StoreQueryRepository.java
+++ b/src/main/java/com/rabbit/dayfilm/store/repository/StoreQueryRepository.java
@@ -1,9 +1,14 @@
 package com.rabbit.dayfilm.store.repository;
 
 import com.rabbit.dayfilm.order.entity.OrderStatus;
+import com.rabbit.dayfilm.store.dto.OrderListCond;
+import com.rabbit.dayfilm.store.dto.OrderListInStoreResDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Map;
 
 public interface StoreQueryRepository {
     Map<OrderStatus, Integer> getOrderCountByStatus(long storeId);
+    Page<OrderListInStoreResDto.OrderList> getOrderListWithPaging(OrderListCond condition, Pageable pageable);
 }

--- a/src/main/java/com/rabbit/dayfilm/store/repository/StoreQueryRepository.java
+++ b/src/main/java/com/rabbit/dayfilm/store/repository/StoreQueryRepository.java
@@ -1,0 +1,9 @@
+package com.rabbit.dayfilm.store.repository;
+
+import com.rabbit.dayfilm.order.entity.OrderStatus;
+
+import java.util.Map;
+
+public interface StoreQueryRepository {
+    Map<OrderStatus, Integer> getOrderCountByStatus(long storeId);
+}

--- a/src/main/java/com/rabbit/dayfilm/store/repository/StoreQueryRepositoryImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/store/repository/StoreQueryRepositoryImpl.java
@@ -56,7 +56,9 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
                                 user.nickname,
                                 order.price,
                                 orderDelivery.code,
-                                orderDelivery.trackingNumber
+                                orderDelivery.trackingNumber,
+                                order.outgoingDate,
+                                order.method
                         )
                 )
                 .from(order)

--- a/src/main/java/com/rabbit/dayfilm/store/repository/StoreQueryRepositoryImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/store/repository/StoreQueryRepositoryImpl.java
@@ -1,14 +1,28 @@
 package com.rabbit.dayfilm.store.repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.rabbit.dayfilm.exception.CustomException;
+import com.rabbit.dayfilm.item.entity.DeliveryMethod;
 import com.rabbit.dayfilm.order.entity.OrderStatus;
+import com.rabbit.dayfilm.store.dto.OrderListCond;
+import com.rabbit.dayfilm.store.dto.OrderListInStoreResDto;
+import com.rabbit.dayfilm.store.dto.QOrderListInStoreResDto_OrderList;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 
+import java.util.List;
 import java.util.Map;
 
 import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.rabbit.dayfilm.item.entity.QItem.item;
 import static com.rabbit.dayfilm.item.entity.QProduct.product;
 import static com.rabbit.dayfilm.order.entity.QOrder.order;
+import static com.rabbit.dayfilm.order.entity.QOrderDelivery.orderDelivery;
+import static com.rabbit.dayfilm.user.entity.QUser.user;
 
 @RequiredArgsConstructor
 public class StoreQueryRepositoryImpl implements StoreQueryRepository {
@@ -27,4 +41,62 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
                                 .as(order.count().castToNum(Integer.class))
                 );
     }
+
+    @Override
+    public Page<OrderListInStoreResDto.OrderList> getOrderListWithPaging(OrderListCond condition, Pageable pageable) {
+        if (condition.getStoreId() == null) throw new CustomException("가게 번호가 올바르지 않습니다.");
+
+        List<OrderListInStoreResDto.OrderList> content = queryFactory
+                .select(
+                        new QOrderListInStoreResDto_OrderList(
+                                order.id,
+                                order.status,
+                                order.orderId,
+                                item.title,
+                                user.nickname,
+                                order.price,
+                                orderDelivery.code,
+                                orderDelivery.trackingNumber
+                        )
+                )
+                .from(order)
+                .leftJoin(orderDelivery)
+                .on(orderDelivery.order.eq(order))
+                .innerJoin(product)
+                .on(product.id.eq(order.productId))
+                .innerJoin(item)
+                .on(product.item.eq(item))
+                .innerJoin(user)
+                .on(user.id.eq(order.userId))
+                .where(
+                        item.store.id.eq(condition.getStoreId()),
+                        eqStatus(condition.getStatus()),
+                        eqMethod(condition.getMethod())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(order.count())
+                .from(order)
+                .innerJoin(product)
+                .on(order.productId.eq(product.id))
+                .where(
+                        product.item.store.id.eq(condition.getStoreId()),
+                        eqStatus(condition.getStatus()),
+                        eqMethod(condition.getMethod())
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression eqStatus(OrderStatus status) {
+        return status != null ? order.status.eq(status) : null;
+    }
+
+    private BooleanExpression eqMethod(DeliveryMethod method) {
+        return method != null ? order.method.eq(method) : null;
+    }
+
 }

--- a/src/main/java/com/rabbit/dayfilm/store/repository/StoreQueryRepositoryImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/store/repository/StoreQueryRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.rabbit.dayfilm.store.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.rabbit.dayfilm.order.entity.OrderStatus;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.rabbit.dayfilm.item.entity.QProduct.product;
+import static com.rabbit.dayfilm.order.entity.QOrder.order;
+
+@RequiredArgsConstructor
+public class StoreQueryRepositoryImpl implements StoreQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Map<OrderStatus, Integer> getOrderCountByStatus(long storeId) {
+        return queryFactory
+                .from(order)
+                .innerJoin(product)
+                .on(product.id.eq(order.productId))
+                .where(product.item.store.id.eq(storeId))
+                .groupBy(order.status)
+                .transform(
+                        groupBy(order.status)
+                                .as(order.count().castToNum(Integer.class))
+                );
+    }
+}

--- a/src/main/java/com/rabbit/dayfilm/store/repository/StoreRepository.java
+++ b/src/main/java/com/rabbit/dayfilm/store/repository/StoreRepository.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-public interface StoreRepository extends JpaRepository<Store, Long> {
+public interface StoreRepository extends JpaRepository<Store, Long>, StoreQueryRepository {
     Optional<Store> findStoreByEmail(String email);
 
     @Transactional

--- a/src/main/java/com/rabbit/dayfilm/store/service/StoreService.java
+++ b/src/main/java/com/rabbit/dayfilm/store/service/StoreService.java
@@ -1,7 +1,11 @@
 package com.rabbit.dayfilm.store.service;
 
 import com.rabbit.dayfilm.store.dto.OrderCountResDto;
+import com.rabbit.dayfilm.store.dto.OrderListCond;
+import com.rabbit.dayfilm.store.dto.OrderListInStoreResDto;
+import org.springframework.data.domain.Pageable;
 
 public interface StoreService {
     OrderCountResDto getOrderCount(Long id);
+    OrderListInStoreResDto getOrderList(OrderListCond condition, Pageable pageable);
 }

--- a/src/main/java/com/rabbit/dayfilm/store/service/StoreService.java
+++ b/src/main/java/com/rabbit/dayfilm/store/service/StoreService.java
@@ -1,11 +1,15 @@
 package com.rabbit.dayfilm.store.service;
 
+import com.rabbit.dayfilm.store.dto.OrderCheckDto;
 import com.rabbit.dayfilm.store.dto.OrderCountResDto;
 import com.rabbit.dayfilm.store.dto.OrderListCond;
 import com.rabbit.dayfilm.store.dto.OrderListInStoreResDto;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface StoreService {
     OrderCountResDto getOrderCount(Long id);
     OrderListInStoreResDto getOrderList(OrderListCond condition, Pageable pageable);
+    List<OrderCheckDto> checkOrders(List<OrderCheckDto> request);
 }

--- a/src/main/java/com/rabbit/dayfilm/store/service/StoreService.java
+++ b/src/main/java/com/rabbit/dayfilm/store/service/StoreService.java
@@ -1,0 +1,7 @@
+package com.rabbit.dayfilm.store.service;
+
+import com.rabbit.dayfilm.store.dto.OrderCountResDto;
+
+public interface StoreService {
+    OrderCountResDto getOrderCount(Long id);
+}

--- a/src/main/java/com/rabbit/dayfilm/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/store/service/StoreServiceImpl.java
@@ -1,6 +1,9 @@
 package com.rabbit.dayfilm.store.service;
 
+import com.rabbit.dayfilm.order.entity.Order;
 import com.rabbit.dayfilm.order.entity.OrderStatus;
+import com.rabbit.dayfilm.order.repository.OrderRepository;
+import com.rabbit.dayfilm.store.dto.OrderCheckDto;
 import com.rabbit.dayfilm.store.dto.OrderCountResDto;
 import com.rabbit.dayfilm.store.dto.OrderListCond;
 import com.rabbit.dayfilm.store.dto.OrderListInStoreResDto;
@@ -9,13 +12,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class StoreServiceImpl implements StoreService {
     private final StoreRepository storeRepository;
+    private final OrderRepository orderRepository;
 
     @Override
     public OrderCountResDto getOrderCount(Long id) {
@@ -32,5 +40,28 @@ public class StoreServiceImpl implements StoreService {
         Page<OrderListInStoreResDto.OrderList> result = storeRepository.getOrderListWithPaging(condition, pageable);
 
         return new OrderListInStoreResDto(result.getContent(), result.getTotalPages(), result.isLast());
+    }
+
+    @Override
+    @Transactional
+    public List<OrderCheckDto> checkOrders(List<OrderCheckDto> request) {
+        request.removeIf(dto -> dto.getOrderPk() == null || dto.getOutgoingDate() == null);
+        List<Long> orderPks = request.stream()
+                .map(OrderCheckDto::getOrderPk)
+                .collect(Collectors.toList());
+
+        List<Order> orders = orderRepository.findAllById(orderPks);
+        List<OrderCheckDto> response = new ArrayList<>();
+
+        for (int i = 0; i < orders.size(); i++) {
+            Order order = orders.get(i);
+            OrderCheckDto dto = request.get(i);
+            if (order.getStatus() == OrderStatus.PAY_DONE) {
+                response.add(dto);
+                order.updateStatus(OrderStatus.RECEIVE_WAIT);
+                order.updateOutgoingDate(dto.getOutgoingDate());
+            }
+        }
+        return response;
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/store/service/StoreServiceImpl.java
@@ -2,8 +2,12 @@ package com.rabbit.dayfilm.store.service;
 
 import com.rabbit.dayfilm.order.entity.OrderStatus;
 import com.rabbit.dayfilm.store.dto.OrderCountResDto;
+import com.rabbit.dayfilm.store.dto.OrderListCond;
+import com.rabbit.dayfilm.store.dto.OrderListInStoreResDto;
 import com.rabbit.dayfilm.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
@@ -21,5 +25,12 @@ public class StoreServiceImpl implements StoreService {
                 countMap.getOrDefault(OrderStatus.DELIVERY, 0),
                 countMap.getOrDefault(OrderStatus.RENTAL, 0)
         );
+    }
+
+    @Override
+    public OrderListInStoreResDto getOrderList(OrderListCond condition, Pageable pageable) {
+        Page<OrderListInStoreResDto.OrderList> result = storeRepository.getOrderListWithPaging(condition, pageable);
+
+        return new OrderListInStoreResDto(result.getContent(), result.getTotalPages(), result.isLast());
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/store/service/StoreServiceImpl.java
@@ -1,0 +1,25 @@
+package com.rabbit.dayfilm.store.service;
+
+import com.rabbit.dayfilm.order.entity.OrderStatus;
+import com.rabbit.dayfilm.store.dto.OrderCountResDto;
+import com.rabbit.dayfilm.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class StoreServiceImpl implements StoreService {
+    private final StoreRepository storeRepository;
+
+    @Override
+    public OrderCountResDto getOrderCount(Long id) {
+        Map<OrderStatus, Integer> countMap = storeRepository.getOrderCountByStatus(id);
+        return new OrderCountResDto(
+                countMap.getOrDefault(OrderStatus.PAY_DONE, 0),
+                countMap.getOrDefault(OrderStatus.DELIVERY, 0),
+                countMap.getOrDefault(OrderStatus.RENTAL, 0)
+        );
+    }
+}

--- a/src/main/java/com/rabbit/dayfilm/user/controller/UserController.java
+++ b/src/main/java/com/rabbit/dayfilm/user/controller/UserController.java
@@ -52,8 +52,10 @@ public class UserController {
 
     /*마이페이지*/
     @GetMapping(EndPoint.ITEM)
-    @Operation(summary = "회원 주문 목록 조회", description = "회원 주문 목록 조회\n회원 번호 넘겨주시면 됩니다.")
-    public ResponseEntity<OrderListResDto> getOrderList(@RequestParam("userId") Long userId, Pageable pageable) {
-        return ResponseEntity.ok(userService.getOrderList(userId, pageable));
+    @Operation(summary = "회원 주문 목록 조회", description = "회원 주문 목록 조회\nisCanceled는 true이면 취소,반품과 같이 취소된게 조회되고, false이면 결제완료,배송완료와 같이 주문 처리(완료) 상태인게 반환됩니다.\n회원 번호 넘겨주시면 됩니다.")
+    public ResponseEntity<OrderListResDto> getOrderList(@RequestParam("userId") Long userId,
+                                                        @RequestParam("isCanceled") Boolean isCanceled,
+                                                        Pageable pageable) {
+        return ResponseEntity.ok(userService.getOrderList(userId, isCanceled, pageable));
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/user/dto/AddressDto.java
+++ b/src/main/java/com/rabbit/dayfilm/user/dto/AddressDto.java
@@ -8,6 +8,9 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class AddressDto {
+
+    @ApiModelProperty(value="주소 번호", example="1", required = true)
+    private Long id;
     @ApiModelProperty(value="주소", example="주소주소", required = true)
     private Address address;
     @ApiModelProperty(value="기본 주소 여부(default)", example="true", required = true)

--- a/src/main/java/com/rabbit/dayfilm/user/repository/UserAddressRepository.java
+++ b/src/main/java/com/rabbit/dayfilm/user/repository/UserAddressRepository.java
@@ -16,6 +16,6 @@ public interface UserAddressRepository extends JpaRepository<UserAddress, Long> 
     @Query("SELECT ua.address FROM UserAddress ua WHERE ua.isDefault=true AND ua.user =:user")
     Optional<Address> findDefaultAddress(@Param("user") User user);
 
-    @Query("SELECT new com.rabbit.dayfilm.user.dto.AddressDto(ua.address, ua.isDefault, ua.nickname) FROM UserAddress ua WHERE ua.user =:user")
+    @Query("SELECT new com.rabbit.dayfilm.user.dto.AddressDto(ua.id, ua.address, ua.isDefault, ua.nickname) FROM UserAddress ua WHERE ua.user =:user")
     List<AddressDto> findAllByUser(@Param("user") User user);
 }

--- a/src/main/java/com/rabbit/dayfilm/user/service/UserAddressServiceImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/user/service/UserAddressServiceImpl.java
@@ -46,7 +46,7 @@ public class UserAddressServiceImpl implements UserAddressService {
 
         List<AddressDto> response = new ArrayList<>();
         for (UserAddress userAddress : user.getAddresses()) {
-            response.add(new AddressDto(userAddress.getAddress(), userAddress.getIsDefault(), userAddress.getNickname()));
+            response.add(new AddressDto(userAddress.getId(), userAddress.getAddress(), userAddress.getIsDefault(), userAddress.getNickname()));
         }
         return response;
     }

--- a/src/main/java/com/rabbit/dayfilm/user/service/UserService.java
+++ b/src/main/java/com/rabbit/dayfilm/user/service/UserService.java
@@ -6,6 +6,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface UserService {
     CodeSet checkNickname(String nickname);
-
-    OrderListResDto getOrderList(Long userId, Pageable pageable);
+    OrderListResDto getOrderList(Long userId, Boolean isCanceled, Pageable pageable);
 }

--- a/src/main/java/com/rabbit/dayfilm/user/service/UserServiceImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/user/service/UserServiceImpl.java
@@ -22,8 +22,8 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public OrderListResDto getOrderList(Long userId, Pageable pageable) {
-        Page<OrderListResDto.OrderList> content = orderRepository.getOrderList(userId, false, pageable);
+    public OrderListResDto getOrderList(Long userId, Boolean isCanceled, Pageable pageable) {
+        Page<OrderListResDto.OrderList> content = orderRepository.getOrderList(userId, isCanceled, pageable);
         return new OrderListResDto(content.getTotalPages(), content.isLast(), content.getContent());
     }
 }


### PR DESCRIPTION
- 주문 상태 업데이트: 회의에서 정해진 비즈니스 로직에 따라서 수정 요망
- 가게 주문 목록 조회 API 구현: 필요에 따라 동적으로 조회
- 회원 주문 목록 조회 API 구현: 필요에 따라 동적으로 조회
- 결제를 위한 토스 결제 객체 생성 API 수정: 배송 방법을 파라미터로 받지 않고 장바구니에 있는 정보를 활용
- 회원 주소지 목록 조회 시, 주소의 PK값도 함께 넘기도록 수정
- 가게 주문 확인 API 구현: 해당 주문의 출고일 지정 및 상태 변경(PAY_DONE -> RECEIVE_WAIT)