### PR TITLE
FEAT: 환불 및 배송 관련 API 구현

### DIFF
--- a/src/main/java/com/rabbit/dayfilm/common/CodeSet.java
+++ b/src/main/java/com/rabbit/dayfilm/common/CodeSet.java
@@ -16,6 +16,7 @@ public enum CodeSet {
     FAIL_AUTHORIZATION("2009", "권한이 없습니다"),
     NOT_FOUND_USER("2010", "회원이 존재하지 않습니다."),
     DUPLICATE_NICKNAME("3000", "중복된 닉네임입니다."),
+    DELETE_ORDER("4000", "주문이 삭제되었습니다"),
     BATCH_ERROR("8000", "배치 서버 동작 중 문제가 생겼습니다."),
     INTERNAL_SERVER_ERROR("9000", "서버 동작 중 문제가 발생했습니다."),
     INVALID_ALGORITHM("9001", "알고리즘이 유효하지 않습니다."),

--- a/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
+++ b/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
@@ -41,4 +41,5 @@ public class EndPoint {
 
     public static final String ITEM_CANCEL = ITEM + "/cancel";
     public static final String ITEM_CANCEL_PROCESS = ITEM_CANCEL + "/process";
+    public static final String ITEM_CANCEL_FINISH = ITEM_CANCEL + "/finish";
 }

--- a/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
+++ b/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
@@ -37,4 +37,6 @@ public class EndPoint {
     public static final String ORDER_CHECK = ORDER + "/check";
     public static final String ORDER_DELIVERY_UPDATE = ORDER + DELIVERY + "/update";
     public static final String ORDER_DONE = ORDER + "/done";
+
+    public static final String TRACKING = "/track";
 }

--- a/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
+++ b/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
@@ -36,4 +36,5 @@ public class EndPoint {
     public static final String ORDER_LIST = ORDER + "/list";
     public static final String ORDER_CHECK = ORDER + "/check";
     public static final String ORDER_DELIVERY_UPDATE = ORDER + DELIVERY + "/update";
+    public static final String ORDER_DONE = ORDER + "/done";
 }

--- a/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
+++ b/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
@@ -14,7 +14,6 @@ public class EndPoint {
     public static final String REVIEW = "/reviews";
     public static final String PRODUCT = "/products";
 
-
     public static final String BASKET = "/basket";
     public static final String ALL = "/all";
 
@@ -39,4 +38,6 @@ public class EndPoint {
     public static final String ORDER_DONE = ORDER + "/done";
 
     public static final String TRACKING = "/track";
+
+    public static final String ITEM_CANCEL = ITEM + "/cancel";
 }

--- a/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
+++ b/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
@@ -40,4 +40,5 @@ public class EndPoint {
     public static final String TRACKING = "/track";
 
     public static final String ITEM_CANCEL = ITEM + "/cancel";
+    public static final String ITEM_CANCEL_PROCESS = ITEM_CANCEL + "/process";
 }

--- a/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
+++ b/src/main/java/com/rabbit/dayfilm/common/EndPoint.java
@@ -31,7 +31,9 @@ public class EndPoint {
     public static final String REDIRECT_FAIL = REDIRECT + "/fail";
 
     public static final String STORE = "/store";
+    public static final String DELIVERY = "/delivery";
     public static final String ORDER_COUNT = ORDER +"/count";
     public static final String ORDER_LIST = ORDER + "/list";
     public static final String ORDER_CHECK = ORDER + "/check";
+    public static final String ORDER_DELIVERY_UPDATE = ORDER + DELIVERY + "/update";
 }

--- a/src/main/java/com/rabbit/dayfilm/common/serializer/OffsetToLocalDateTimeSerializer.java
+++ b/src/main/java/com/rabbit/dayfilm/common/serializer/OffsetToLocalDateTimeSerializer.java
@@ -1,0 +1,17 @@
+package com.rabbit.dayfilm.common.serializer;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+public class OffsetToLocalDateTimeSerializer extends JsonDeserializer<LocalDateTime> {
+    @Override
+    public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+        return OffsetDateTime.parse(p.getText()).toLocalDateTime();
+    }
+}

--- a/src/main/java/com/rabbit/dayfilm/config/SecurityConfig.java
+++ b/src/main/java/com/rabbit/dayfilm/config/SecurityConfig.java
@@ -54,7 +54,10 @@ public class SecurityConfig {
                 .csrf().disable()
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeRequests()
-                .antMatchers("/items/store-write/**").hasRole(Role.STORE.name())
+                .antMatchers(
+                        "/items/store-write/**",
+                        "/store/**"
+                ).hasRole(Role.STORE.name())
                 .antMatchers(
                         "/user/**",
                         "/basket/**",

--- a/src/main/java/com/rabbit/dayfilm/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/rabbit/dayfilm/delivery/controller/DeliveryController.java
@@ -1,0 +1,29 @@
+package com.rabbit.dayfilm.delivery.controller;
+
+import com.rabbit.dayfilm.common.EndPoint;
+import com.rabbit.dayfilm.delivery.dto.DeliveryTrackingDto;
+import com.rabbit.dayfilm.delivery.service.DeliveryService;
+import com.rabbit.dayfilm.delivery.dto.DeliveryCode;
+import io.swagger.annotations.Api;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Api(tags = "배송")
+@RequestMapping(EndPoint.DELIVERY)
+public class DeliveryController {
+    private final DeliveryService deliveryService;
+    @GetMapping(EndPoint.TRACKING)
+    @Operation(summary = "배송 추적", description = "주문 번호와 함께 배송 정보(택배회사,운송장번호)를 넘겨주시면 됩니다.\n택배회사는 배송정보 등록과 동일하게 kr을 제외한 코드를 대문자로 전송해주세요.\n운송장 번호는 숫자만 오거나, 123-456-789와 같은 형태만 가능합니다.")
+    public ResponseEntity<DeliveryTrackingDto> tracking(@RequestParam("orderPk") Long orderPk,
+                                                        @RequestParam("company") DeliveryCode company,
+                                                        @RequestParam("trackingNumber") String trackingNumber) {
+        return ResponseEntity.ok().body(deliveryService.tracking(orderPk, company, trackingNumber.replaceAll("-", "")));
+    }
+}

--- a/src/main/java/com/rabbit/dayfilm/delivery/dto/DeliveryCode.java
+++ b/src/main/java/com/rabbit/dayfilm/delivery/dto/DeliveryCode.java
@@ -1,4 +1,4 @@
-package com.rabbit.dayfilm.order.entity;
+package com.rabbit.dayfilm.delivery.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/rabbit/dayfilm/delivery/dto/DeliveryStatus.java
+++ b/src/main/java/com/rabbit/dayfilm/delivery/dto/DeliveryStatus.java
@@ -1,0 +1,23 @@
+package com.rabbit.dayfilm.delivery.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.rabbit.dayfilm.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public enum DeliveryStatus {
+    INFORMATION_RECEIVED,
+    AT_PICKUP,
+    IN_TRANSIT,
+    OUT_FOR_DELIVERY,
+    DELIVERED;
+
+    @JsonCreator
+    public static DeliveryStatus fromString(String status) {
+        for (DeliveryStatus d : DeliveryStatus.values()) {
+            if (d.name().toLowerCase().equals(status))
+                return d;
+        }
+        throw new CustomException("배송 정보가 올바르지 않습니다.");
+    }
+}

--- a/src/main/java/com/rabbit/dayfilm/delivery/dto/DeliveryTracker.java
+++ b/src/main/java/com/rabbit/dayfilm/delivery/dto/DeliveryTracker.java
@@ -1,0 +1,84 @@
+package com.rabbit.dayfilm.delivery.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.rabbit.dayfilm.common.serializer.OffsetToLocalDateTimeSerializer;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeliveryTracker {
+    private FromToInfo from;
+    private FromToInfo to;
+    private TrackerState state;
+    private List<TrackerProgress> progresses;
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class FromToInfo {
+        @ApiModelProperty(value="이름(보낸사람or받는사람)", example="박*호")
+        private String name;
+
+        @ApiModelProperty(value="시간(보낸시간or받은시간)", example="2023-03-28T23:01:00")
+        @JsonDeserialize(using = OffsetToLocalDateTimeSerializer.class)
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        private LocalDateTime time;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class TrackerState {
+        @ApiModelProperty(value="배송 상태(코드)", example="DELIVERED")
+        private DeliveryStatus id;
+
+        @ApiModelProperty(value="배송 상태(텍스트)", example="배송 완료")
+        private String text;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class TrackerProgress {
+        @ApiModelProperty(value="시간", example="2023-03-28T23:01:00")
+        @JsonDeserialize(using = OffsetToLocalDateTimeSerializer.class)
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        private LocalDateTime time;
+
+        @ApiModelProperty(value="장소", example="수지직영(오수현)")
+        private TrackerLocation location;
+
+        private TrackerStatus status;
+
+        @ApiModelProperty(value="진행 현황", example="보내시는 고객님으로부터 상품을 인수받았습니다.")
+        private String description;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class TrackerLocation {
+        @ApiModelProperty(value="장소", example="수지직영(오수현)")
+        private String name;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class TrackerStatus {
+        @ApiModelProperty(value="배송 상태(코드)", example="IN_TRANSIT")
+        private DeliveryStatus id;
+
+        @ApiModelProperty(value="배송 상태(텍스트)", example="상품이동중")
+        private String text;
+    }
+}

--- a/src/main/java/com/rabbit/dayfilm/delivery/dto/DeliveryTrackingDto.java
+++ b/src/main/java/com/rabbit/dayfilm/delivery/dto/DeliveryTrackingDto.java
@@ -1,0 +1,37 @@
+package com.rabbit.dayfilm.delivery.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class DeliveryTrackingDto {
+    private DeliveryProductInfo productInfo;
+    private DeliveryTracker tracker;
+
+    @Getter
+    @NoArgsConstructor
+    public static class DeliveryProductInfo {
+        @ApiModelProperty(value="상품 제목", example = "캐논 카메라")
+        private String title;
+
+        @ApiModelProperty(value="상품 썸네일", example = "1")
+        private String imagePath;
+
+        @ApiModelProperty(value="주문 시간", example = "2023-03-28T12:00:23")
+        private LocalDateTime orderDate;
+
+        @QueryProjection
+        public DeliveryProductInfo(String title, String imagePath, LocalDateTime orderTime) {
+            this.title = title;
+            this.imagePath = imagePath;
+            this.orderDate = orderTime;
+        }
+    }
+}

--- a/src/main/java/com/rabbit/dayfilm/delivery/service/DeliveryService.java
+++ b/src/main/java/com/rabbit/dayfilm/delivery/service/DeliveryService.java
@@ -1,0 +1,8 @@
+package com.rabbit.dayfilm.delivery.service;
+
+import com.rabbit.dayfilm.delivery.dto.DeliveryCode;
+import com.rabbit.dayfilm.delivery.dto.DeliveryTrackingDto;
+
+public interface DeliveryService {
+    DeliveryTrackingDto tracking(Long orderPk, DeliveryCode company, String trackingNumber);
+}

--- a/src/main/java/com/rabbit/dayfilm/delivery/service/DeliveryServiceImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/delivery/service/DeliveryServiceImpl.java
@@ -1,0 +1,54 @@
+package com.rabbit.dayfilm.delivery.service;
+
+import com.rabbit.dayfilm.delivery.dto.DeliveryTracker;
+import com.rabbit.dayfilm.delivery.dto.DeliveryTrackingDto;
+import com.rabbit.dayfilm.exception.CustomException;
+import com.rabbit.dayfilm.delivery.dto.DeliveryCode;
+import com.rabbit.dayfilm.order.entity.Order;
+import com.rabbit.dayfilm.order.entity.OrderStatus;
+import com.rabbit.dayfilm.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import javax.annotation.PostConstruct;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryServiceImpl implements DeliveryService {
+    private final OrderRepository orderRepository;
+
+    WebClient webClient;
+    @PostConstruct
+    public void init() {
+        webClient = WebClient.builder()
+                .baseUrl("https://apis.tracker.delivery/carriers")
+                .defaultHeaders(header -> header.setContentType(MediaType.APPLICATION_JSON))
+                .build();
+    }
+
+    @Override
+    public DeliveryTrackingDto tracking(Long orderPk, DeliveryCode code, String trackingNumber) {
+        Order order = orderRepository.findById(orderPk).orElseThrow(() -> new CustomException("주문이 존재하지 않습니다."));
+        if (!(order.getStatus() == OrderStatus.DELIVERY || order.getStatus() == OrderStatus.RETURN_DELIVERY))
+            throw new CustomException("배송 중인 주문이 아닙니다.");
+
+
+        DeliveryTracker tracker = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/{carrierId}/tracks/{trackId}")
+                        .build(code.getId(), trackingNumber)
+                )
+                .retrieve()
+                .onStatus(HttpStatus::is4xxClientError, res -> Mono.error(new CustomException("배송 정보가 올바르지 않습니다.")))
+                .onStatus(HttpStatus::is5xxServerError, res -> Mono.error(new CustomException("배송 정보를 추적할 수 없습니다.")))
+                .bodyToMono(DeliveryTracker.class)
+                .block();
+
+        DeliveryTrackingDto.DeliveryProductInfo productInfo = orderRepository.getProductDeliveryInfo(orderPk);
+        return new DeliveryTrackingDto(productInfo, tracker);
+    }
+}

--- a/src/main/java/com/rabbit/dayfilm/order/entity/DeliveryCode.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/DeliveryCode.java
@@ -6,12 +6,27 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum DeliveryCode {
-    LOTTE("롯데 택배");
+    CHUNILPS("kr.chunilps", "천일택배", "+8218776606"),
+    CJLOGISTICS("kr.cjlogistics", "CJ대한통운", "+8215881255"),
+    CUPOST("kr.cupost", "CU 편의점택배", "+8215771287"),
+    CVSNET("kr.cvsnet", "GS Postbox 택배", "+8215771287"),
+    CWAY("kr.cway", "CWAY (Woori Express", "+8215884899"),
+    DAESIN("kr.deasin", "대신택배", "+82314620100"),
+    EPOST("kr.epost", "우체국 택배", "+8215881300"),
+    HANIPS("kr.hanips", "한의사랑택배", "+8216001055"),
+    HANJIN("kr.hanjin", "한진택배", "+8215880011"),
+    HDEXP("kr.hdexp", "합동택배", "+8218993392"),
+    HOMEPICK("kr.homepick", "홈픽", "+8218000987"),
+    HONAMLOGIS("kr.honamlogis", "한서호남택배", "+8218770572"),
+    ILYANGLOGIS("kr.ilyanglogis", "일양로지스", "+8215880002"),
+    KDEXP("kr.kdexp", "경동택배", "+8218995368"),
+    KUNYOUNG("kr.kunyoung", "건영택배", "+82533543001"),
+    LOGEN("kr.logen", "로젠택배", "+8215889988"),
+    LOTTE("kr.lotte", "롯데택배", "+8215882121"),
+    SLX("kr.slx", "SLX", "+82316375400"),
+    SWGEXP("kr.swgexp", "성원글로벌카고", "+82327469984");
 
-    /**
-     * 포맷 미정 (택배사 API 결정 후 작성 예정)
-     */
-
-    private String title;
-
+    private String id;
+    private String name;
+    private String tel;
 }

--- a/src/main/java/com/rabbit/dayfilm/order/entity/Order.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/Order.java
@@ -67,4 +67,8 @@ public class Order {
     public void updateOutgoingDate(LocalDate outgoingDate) {
         this.outgoingDate = outgoingDate;
     }
+    public void setDelivery(OrderDelivery delivery) {
+        this.delivery = delivery;
+        delivery.setOrder(this);
+    }
 }

--- a/src/main/java/com/rabbit/dayfilm/order/entity/Order.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/Order.java
@@ -74,4 +74,8 @@ public class Order {
         this.orderDelivery = delivery;
         delivery.setOrder(this);
     }
+    public void setReturnDelivery(OrderReturnDelivery returnDelivery) {
+        this.returnDelivery = returnDelivery;
+        returnDelivery.setOrder(this);
+    }
 }

--- a/src/main/java/com/rabbit/dayfilm/order/entity/Order.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/Order.java
@@ -59,7 +59,10 @@ public class Order {
     private Integer price;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private OrderDelivery delivery;
+    private OrderDelivery orderDelivery;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private OrderReturnDelivery returnDelivery;
 
     public void updateStatus(OrderStatus status) {
         this.status = status;
@@ -67,8 +70,8 @@ public class Order {
     public void updateOutgoingDate(LocalDate outgoingDate) {
         this.outgoingDate = outgoingDate;
     }
-    public void setDelivery(OrderDelivery delivery) {
-        this.delivery = delivery;
+    public void setOrderDelivery(OrderDelivery delivery) {
+        this.orderDelivery = delivery;
         delivery.setOrder(this);
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/order/entity/Order.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/Order.java
@@ -62,7 +62,7 @@ public class Order {
     private OrderDelivery orderDelivery;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private OrderReturnDelivery returnDelivery;
+    private OrderReturnInfo returnInfo;
 
     public void updateStatus(OrderStatus status) {
         this.status = status;
@@ -74,8 +74,8 @@ public class Order {
         this.orderDelivery = delivery;
         delivery.setOrder(this);
     }
-    public void setReturnDelivery(OrderReturnDelivery returnDelivery) {
-        this.returnDelivery = returnDelivery;
+    public void setReturnInfo(OrderReturnInfo returnDelivery) {
+        this.returnInfo = returnDelivery;
         returnDelivery.setOrder(this);
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/order/entity/OrderDelivery.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/OrderDelivery.java
@@ -1,8 +1,13 @@
 package com.rabbit.dayfilm.order.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 
 @Entity
+@AllArgsConstructor
+@NoArgsConstructor
 public class OrderDelivery {
     @Id @GeneratedValue
     @Column(name = "delivery_id")
@@ -17,4 +22,13 @@ public class OrderDelivery {
 
     @Column(name = "tracking_number", nullable = false)
     private String trackingNumber;
+
+    public OrderDelivery(Order order, DeliveryCode code, String trackingNumber) {
+        this.order = order;
+        this.code = code;
+        this.trackingNumber = trackingNumber;
+    }
+    public void setOrder(Order order) {
+        this.order = order;
+    }
 }

--- a/src/main/java/com/rabbit/dayfilm/order/entity/OrderDelivery.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/OrderDelivery.java
@@ -14,7 +14,7 @@ public class OrderDelivery {
     @Column(name = "delivery_id")
     private Long id;
 
-    @OneToOne(mappedBy = "delivery", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "orderDelivery", fetch = FetchType.LAZY)
     private Order order;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/rabbit/dayfilm/order/entity/OrderDelivery.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/OrderDelivery.java
@@ -1,5 +1,6 @@
 package com.rabbit.dayfilm.order.entity;
 
+import com.rabbit.dayfilm.delivery.dto.DeliveryCode;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/rabbit/dayfilm/order/entity/OrderReturnDelivery.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/OrderReturnDelivery.java
@@ -2,11 +2,13 @@ package com.rabbit.dayfilm.order.entity;
 
 import com.rabbit.dayfilm.delivery.dto.DeliveryCode;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class OrderReturnDelivery {
@@ -28,8 +30,17 @@ public class OrderReturnDelivery {
     @Column(name = "cancel_reason")
     private String cancelReason;
 
-    public OrderReturnDelivery(Order order, String cancelReason) {
+    @Column(name = "prev_status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private OrderStatus prevStatus;
+
+
+    public OrderReturnDelivery(Order order, String cancelReason, OrderStatus prevStatus) {
         this.order = order;
         this.cancelReason = cancelReason;
+        this.prevStatus = prevStatus;
+    }
+    public void setOrder(Order order) {
+        this.order = order;
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/order/entity/OrderReturnDelivery.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/OrderReturnDelivery.java
@@ -1,0 +1,35 @@
+package com.rabbit.dayfilm.order.entity;
+
+import com.rabbit.dayfilm.delivery.dto.DeliveryCode;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderReturnDelivery {
+    @Id
+    @GeneratedValue
+    @Column(name = "return_delivery_id")
+    private Long id;
+
+    @OneToOne(mappedBy = "returnDelivery", fetch = FetchType.LAZY)
+    private Order order;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "code")
+    private DeliveryCode code;
+
+    @Column(name = "tracking_number")
+    private String trackingNumber;
+
+    @Column(name = "cancel_reason")
+    private String cancelReason;
+
+    public OrderReturnDelivery(Order order, String cancelReason) {
+        this.order = order;
+        this.cancelReason = cancelReason;
+    }
+}

--- a/src/main/java/com/rabbit/dayfilm/order/entity/OrderReturnInfo.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/OrderReturnInfo.java
@@ -11,13 +11,13 @@ import javax.persistence.*;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class OrderReturnDelivery {
+public class OrderReturnInfo {
     @Id
     @GeneratedValue
     @Column(name = "return_delivery_id")
     private Long id;
 
-    @OneToOne(mappedBy = "returnDelivery", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "returnInfo", fetch = FetchType.LAZY)
     private Order order;
 
     @Enumerated(EnumType.STRING)
@@ -35,7 +35,7 @@ public class OrderReturnDelivery {
     private OrderStatus prevStatus;
 
 
-    public OrderReturnDelivery(Order order, String cancelReason, OrderStatus prevStatus) {
+    public OrderReturnInfo(Order order, String cancelReason, OrderStatus prevStatus) {
         this.order = order;
         this.cancelReason = cancelReason;
         this.prevStatus = prevStatus;

--- a/src/main/java/com/rabbit/dayfilm/order/entity/OrderStatus.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/OrderStatus.java
@@ -11,7 +11,6 @@ public enum OrderStatus {
 
     //발송완료
     RENTAL,
-    RETURN,
     RETURN_DELIVERY,
 
     //환불

--- a/src/main/java/com/rabbit/dayfilm/order/entity/OrderStatus.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/OrderStatus.java
@@ -1,5 +1,6 @@
 package com.rabbit.dayfilm.order.entity;
 
+import java.util.Arrays;
 import java.util.List;
 
 public enum OrderStatus {
@@ -25,5 +26,11 @@ public enum OrderStatus {
 
     public static List<OrderStatus> getCancelStatus() {
         return List.of(CANCEL_WAIT, CANCEL_DELIVERY, CANCEL);
+    }
+
+    public static List<OrderStatus> getNotCancelStatus() {
+        List<OrderStatus> result = Arrays.asList(OrderStatus.values());
+        result.removeAll(getCancelStatus());
+        return result;
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/order/entity/OrderStatus.java
+++ b/src/main/java/com/rabbit/dayfilm/order/entity/OrderStatus.java
@@ -1,5 +1,7 @@
 package com.rabbit.dayfilm.order.entity;
 
+import java.util.List;
+
 public enum OrderStatus {
     //주문접수
     PAY_WAITING,
@@ -14,8 +16,14 @@ public enum OrderStatus {
     RETURN_DELIVERY,
 
     //환불
+    CANCEL_WAIT,
     CANCEL,
+    CANCEL_DELIVERY,
 
     //사용 완료
-    DONE
+    DONE;
+
+    public static List<OrderStatus> getCancelStatus() {
+        return List.of(CANCEL_WAIT, CANCEL_DELIVERY, CANCEL);
+    }
 }

--- a/src/main/java/com/rabbit/dayfilm/order/repository/OrderQueryRepository.java
+++ b/src/main/java/com/rabbit/dayfilm/order/repository/OrderQueryRepository.java
@@ -1,9 +1,11 @@
 package com.rabbit.dayfilm.order.repository;
 
+import com.rabbit.dayfilm.delivery.dto.DeliveryTrackingDto;
 import com.rabbit.dayfilm.user.dto.OrderListResDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface OrderQueryRepository {
     Page<OrderListResDto.OrderList> getOrderList(Long userId, boolean isCanceled, Pageable pageable);
+    DeliveryTrackingDto.DeliveryProductInfo getProductDeliveryInfo(Long orderPk);
 }

--- a/src/main/java/com/rabbit/dayfilm/order/repository/OrderQueryRepositoryImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/order/repository/OrderQueryRepositoryImpl.java
@@ -19,6 +19,7 @@ import static com.rabbit.dayfilm.item.entity.QItem.item;
 import static com.rabbit.dayfilm.item.entity.QItemImage.itemImage;
 import static com.rabbit.dayfilm.item.entity.QProduct.product;
 import static com.rabbit.dayfilm.order.entity.QOrder.order;
+import static com.rabbit.dayfilm.payment.entity.QPayInformation.payInformation;
 
 @RequiredArgsConstructor
 public class OrderQueryRepositoryImpl implements OrderQueryRepository {
@@ -34,12 +35,16 @@ public class OrderQueryRepositoryImpl implements OrderQueryRepository {
                         order.created,
                         order.started,
                         order.ended,
+                        order.orderId,
                         order.status,
-                        order.price
+                        order.price,
+                        payInformation.method
                 ))
                 .from(order)
                 .innerJoin(product)
                 .on(order.productId.eq(product.id))
+                .innerJoin(payInformation)
+                .on(payInformation.orderId.eq(order.orderId))
                 .innerJoin(item)
                 .on(product.in(item.products))
                 .leftJoin(itemImage)

--- a/src/main/java/com/rabbit/dayfilm/order/repository/OrderQueryRepositoryImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/order/repository/OrderQueryRepositoryImpl.java
@@ -90,6 +90,7 @@ public class OrderQueryRepositoryImpl implements OrderQueryRepository {
     }
 
     private BooleanExpression setStatus(boolean isCanceled) {
-        return isCanceled ? order.status.eq(OrderStatus.CANCEL) : order.status.ne(OrderStatus.CANCEL);
+        List<OrderStatus> cancelStatus = OrderStatus.getCancelStatus();
+        return isCanceled ? order.status.in(cancelStatus) : order.status.notIn(cancelStatus);
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/order/repository/OrderReturnDeliveryRepository.java
+++ b/src/main/java/com/rabbit/dayfilm/order/repository/OrderReturnDeliveryRepository.java
@@ -1,7 +1,0 @@
-package com.rabbit.dayfilm.order.repository;
-
-import com.rabbit.dayfilm.order.entity.OrderReturnDelivery;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface OrderReturnDeliveryRepository extends JpaRepository<OrderReturnDelivery, Long> {
-}

--- a/src/main/java/com/rabbit/dayfilm/order/repository/OrderReturnDeliveryRepository.java
+++ b/src/main/java/com/rabbit/dayfilm/order/repository/OrderReturnDeliveryRepository.java
@@ -1,0 +1,7 @@
+package com.rabbit.dayfilm.order.repository;
+
+import com.rabbit.dayfilm.order.entity.OrderReturnDelivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderReturnDeliveryRepository extends JpaRepository<OrderReturnDelivery, Long> {
+}

--- a/src/main/java/com/rabbit/dayfilm/payment/dto/PaymentCancelReqDto.java
+++ b/src/main/java/com/rabbit/dayfilm/payment/dto/PaymentCancelReqDto.java
@@ -1,6 +1,5 @@
 package com.rabbit.dayfilm.payment.dto;
 
-import com.rabbit.dayfilm.payment.toss.object.TossCardCode;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,20 +11,13 @@ import java.util.List;
 public class PaymentCancelReqDto {
     @ApiModelProperty(value="주문 번호", example="2023030901831", required = true)
     private String orderId;
+
     @ApiModelProperty(value="환불 사유", example="고객 변심", required = true)
     private String reason;
+
     @ApiModelProperty(value="주문 번호의 PK", example="[1,2,3,4,5]", required = true)
     private List<Long> orderPrimaryId;
+
     @ApiModelProperty(value="가상 계좌의 경우 필요한 환불 정보", example="{~~}", required = true)
     private RefundReceiveAccount refundReceiveAccount;
-
-    public static class RefundReceiveAccount {
-        @ApiModelProperty(value="은행 코드", example="3K", required = true)
-        private TossCardCode bank;
-
-        @ApiModelProperty(value="계좌 번호", example="123456789", required = true)
-        private String accountNumber;
-        @ApiModelProperty(value="에금주", example="박찬호", required = true)
-        private String holdNumber;
-    }
 }

--- a/src/main/java/com/rabbit/dayfilm/payment/dto/RefundReceiveAccount.java
+++ b/src/main/java/com/rabbit/dayfilm/payment/dto/RefundReceiveAccount.java
@@ -1,0 +1,21 @@
+package com.rabbit.dayfilm.payment.dto;
+
+import com.rabbit.dayfilm.payment.toss.object.TossCardCode;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RefundReceiveAccount {
+    @ApiModelProperty(value="은행 코드", example="3K", required = true)
+    private TossCardCode bank;
+
+    @ApiModelProperty(value="계좌 번호", example="123456789", required = true)
+    private String accountNumber;
+
+    @ApiModelProperty(value="에금주", example="박찬호", required = true)
+    private String holdName;
+}

--- a/src/main/java/com/rabbit/dayfilm/payment/dto/RefundReceiveAccount.java
+++ b/src/main/java/com/rabbit/dayfilm/payment/dto/RefundReceiveAccount.java
@@ -1,5 +1,6 @@
 package com.rabbit.dayfilm.payment.dto;
 
+import com.rabbit.dayfilm.payment.entity.VirtualAccountRefundInfo;
 import com.rabbit.dayfilm.payment.toss.object.TossCardCode;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
@@ -18,4 +19,10 @@ public class RefundReceiveAccount {
 
     @ApiModelProperty(value="에금주", example="박찬호", required = true)
     private String holdName;
+
+    public RefundReceiveAccount(VirtualAccountRefundInfo virtualAccountRefundInfo) {
+        this.bank = virtualAccountRefundInfo.getBank();
+        this.accountNumber = virtualAccountRefundInfo.getAccountNumber();
+        this.holdName = virtualAccountRefundInfo.getHoldName();
+    }
 }

--- a/src/main/java/com/rabbit/dayfilm/payment/entity/CancelPayment.java
+++ b/src/main/java/com/rabbit/dayfilm/payment/entity/CancelPayment.java
@@ -17,22 +17,31 @@ public class CancelPayment {
     @Id @GeneratedValue
     @Column(name = "cancel_id")
     private Long cancelId;
+
     @Column(name = "order_id", nullable = false)
     private String orderId;
+
     @Column(name = "cancel_reason", nullable = false)
     private String cancelReason;
+
     @Column(name = "canceled_at", nullable = false)
     private LocalDateTime canceledAt;
+
     @Column(name = "account_number", nullable = false)
     private Integer cancelAmount;
+
     @Column(name = "tax_free_amount", nullable = false)
     private Integer taxFreeAmount;
+
     @Column(name = "tax_exemption_amount", nullable = false)
     private Integer taxExemptionAmount;
+
     @Column(name = "refundable_amount", nullable = false)
     private Integer refundableAmount;
-    @Column(name = "easypay_disscount_amount", nullable = false)
+
+    @Column(name = "easypay_discount_amount", nullable = false)
     private Integer easyPayDiscountAmount;
+
     @Column(name = "transaction_key", nullable = false)
     private String transactionKey;
 }

--- a/src/main/java/com/rabbit/dayfilm/payment/entity/EasyPayment.java
+++ b/src/main/java/com/rabbit/dayfilm/payment/entity/EasyPayment.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@DiscriminatorValue("easy")
+@DiscriminatorValue("easy_payment")
 public class EasyPayment extends PayInformation {
     public EasyPayment(PayInformation payInformation, String orderId, EasyPayCode easyPayCode, Integer discountAmount) {
         super(payInformation);
@@ -20,12 +20,15 @@ public class EasyPayment extends PayInformation {
         this.easyPayCode = easyPayCode;
         this.discountAmount = discountAmount;
     }
+
     @Id
     @Column(name = "order_id")
     private String orderId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "easy_pay_code", nullable = false)
     private EasyPayCode easyPayCode;
+
     @Column(name = "discount_amount", nullable = false)
     private Integer discountAmount;
 }

--- a/src/main/java/com/rabbit/dayfilm/payment/entity/PayInformation.java
+++ b/src/main/java/com/rabbit/dayfilm/payment/entity/PayInformation.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Inheritance(strategy = InheritanceType.JOINED)
-@DiscriminatorColumn(name="method")
+@DiscriminatorColumn(name="method", discriminatorType = DiscriminatorType.STRING)
 public class PayInformation {
     public PayInformation(PayInformation payInformation) {
         this.orderId = payInformation.getOrderId();
@@ -52,6 +52,9 @@ public class PayInformation {
     private Integer vat;
     @Column(name = "type", nullable = false)
     private String type;
+
+    @Column(name = "method", insertable = false, updatable = false)
+    private String method;
 
     public void updateStatus(PayStatus status) {
         this.status = status;

--- a/src/main/java/com/rabbit/dayfilm/payment/entity/VirtualAccountRefundInfo.java
+++ b/src/main/java/com/rabbit/dayfilm/payment/entity/VirtualAccountRefundInfo.java
@@ -1,0 +1,33 @@
+package com.rabbit.dayfilm.payment.entity;
+
+import com.rabbit.dayfilm.payment.dto.RefundReceiveAccount;
+import com.rabbit.dayfilm.payment.toss.object.TossCardCode;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class VirtualAccountRefundInfo {
+    @Id
+    private String orderId; // 하나씩 취소할경우 있으면 조회하고 없으면 생성하는 방식
+
+    @Column(name = "bank")
+    @Enumerated(EnumType.STRING)
+    private TossCardCode bank;
+
+    @Column(name = "account_number")
+    private String accountNumber;
+
+    @Column(name = "hold_name")
+    private String holdName;
+
+    public VirtualAccountRefundInfo(String orderId, RefundReceiveAccount account) {
+        this.orderId = orderId;
+        this.bank = account.getBank();
+        this.accountNumber = account.getAccountNumber();
+        this.holdName = account.getHoldName();
+    }
+}

--- a/src/main/java/com/rabbit/dayfilm/payment/entity/VirtualAccountRefundInfo.java
+++ b/src/main/java/com/rabbit/dayfilm/payment/entity/VirtualAccountRefundInfo.java
@@ -3,16 +3,18 @@ package com.rabbit.dayfilm.payment.entity;
 import com.rabbit.dayfilm.payment.dto.RefundReceiveAccount;
 import com.rabbit.dayfilm.payment.toss.object.TossCardCode;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class VirtualAccountRefundInfo {
     @Id
-    private String orderId; // 하나씩 취소할경우 있으면 조회하고 없으면 생성하는 방식
+    private String orderId;
 
     @Column(name = "bank")
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/rabbit/dayfilm/payment/repository/PayPerMethodRepository.java
+++ b/src/main/java/com/rabbit/dayfilm/payment/repository/PayPerMethodRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Repository
@@ -23,7 +24,7 @@ public class PayPerMethodRepository<T extends PayInformation> {
         em.persist(object);
     }
 
-    public VirtualAccountPayment findVirtual(String orderId) {
-        return em.find(VirtualAccountPayment.class, orderId);
+    public Optional<VirtualAccountPayment> findVirtual(String orderId) {
+        return Optional.ofNullable(em.find(VirtualAccountPayment.class, orderId));
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/payment/repository/PayRepository.java
+++ b/src/main/java/com/rabbit/dayfilm/payment/repository/PayRepository.java
@@ -2,6 +2,10 @@ package com.rabbit.dayfilm.payment.repository;
 
 import com.rabbit.dayfilm.payment.entity.PayInformation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface PayRepository extends JpaRepository<PayInformation, String> {
+    Optional<PayInformation> findByOrderId(@Param("orderId") String orderId);
 }

--- a/src/main/java/com/rabbit/dayfilm/payment/repository/VirtualAccountRefundRepository.java
+++ b/src/main/java/com/rabbit/dayfilm/payment/repository/VirtualAccountRefundRepository.java
@@ -1,0 +1,7 @@
+package com.rabbit.dayfilm.payment.repository;
+
+import com.rabbit.dayfilm.payment.entity.VirtualAccountRefundInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VirtualAccountRefundRepository extends JpaRepository<VirtualAccountRefundInfo, String> {
+}

--- a/src/main/java/com/rabbit/dayfilm/payment/toss/controller/TossController.java
+++ b/src/main/java/com/rabbit/dayfilm/payment/toss/controller/TossController.java
@@ -43,7 +43,6 @@ public class TossController {
         } else {
             return ResponseEntity.ok("취소");
         }
-
     }
 
     @GetMapping(EndPoint.REDIRECT_FAIL)
@@ -52,11 +51,5 @@ public class TossController {
                                                          @RequestParam("message") String message,
                                                          @RequestParam("orderId") String orderId) {
         return ResponseEntity.ok().body(tossService.cancelOrder(orderId, message));
-    }
-
-    @PostMapping(EndPoint.CANCEL)
-    @Operation(summary = "환불", description = "결제가 완료된 상품을 환불합니다.")
-    public ResponseEntity<PaymentCancelResDto> paymentCancel(@RequestBody PaymentCancelReqDto request) {
-        return ResponseEntity.ok().body(tossService.cancelPayment(request));
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/payment/toss/object/Method.java
+++ b/src/main/java/com/rabbit/dayfilm/payment/toss/object/Method.java
@@ -30,4 +30,14 @@ public enum Method {
         }
         throw new CustomException("결제 정보가 올바르지 않습니다.");
     }
+
+    public static Method findMethod(String method) {
+        method = method.toLowerCase();
+        for (Method m : Method.values()) {
+            if (m.name().toLowerCase().equals(method)) {
+                return m;
+            }
+        }
+        throw new CustomException("결제 정보가 올바르지 않습니다.");
+    }
 }

--- a/src/main/java/com/rabbit/dayfilm/payment/toss/service/TossService.java
+++ b/src/main/java/com/rabbit/dayfilm/payment/toss/service/TossService.java
@@ -1,14 +1,15 @@
 package com.rabbit.dayfilm.payment.toss.service;
 
 
-import com.rabbit.dayfilm.payment.dto.PaymentCancelReqDto;
+import com.rabbit.dayfilm.order.entity.Order;
 import com.rabbit.dayfilm.payment.dto.PaymentCancelResDto;
+import com.rabbit.dayfilm.payment.dto.RefundReceiveAccount;
+import com.rabbit.dayfilm.payment.entity.PayInformation;
 import com.rabbit.dayfilm.payment.toss.dto.TossOrderInfo;
 
 public interface TossService {
     boolean paymentConfirm(String paymentKey, String orderId, Integer amount);
     boolean checkOrder(String orderId);
-
     TossOrderInfo cancelOrder(String orderId, String message);
-    PaymentCancelResDto cancelPayment(PaymentCancelReqDto request);
+    PaymentCancelResDto cancelPayment(PayInformation payment, Order order, RefundReceiveAccount refundReceiveAccount, String cancelReason);
 }

--- a/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
+++ b/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
@@ -1,12 +1,7 @@
 package com.rabbit.dayfilm.store.controller;
 
-import com.rabbit.dayfilm.common.CodeSet;
 import com.rabbit.dayfilm.common.EndPoint;
-import com.rabbit.dayfilm.common.response.SuccessResponse;
-import com.rabbit.dayfilm.store.dto.OrderCheckDto;
-import com.rabbit.dayfilm.store.dto.OrderCountResDto;
-import com.rabbit.dayfilm.store.dto.OrderListCond;
-import com.rabbit.dayfilm.store.dto.OrderListInStoreResDto;
+import com.rabbit.dayfilm.store.dto.*;
 import com.rabbit.dayfilm.store.service.StoreService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -39,5 +34,11 @@ public class StoreController {
     @Operation(summary = "주문 확인(출고일 지정)", description = "해당 주문의 출고일을 지정합니다.\n출고일이 지정된 주문 내용을 반환합니다.")
     public ResponseEntity<List<OrderCheckDto>> checkOrders(@RequestBody List<OrderCheckDto> request) {
         return ResponseEntity.ok().body(storeService.checkOrders(request));
+    }
+
+    @PostMapping(EndPoint.ORDER_DELIVERY_UPDATE)
+    @Operation(summary = "배송 진행 처리", description = "주문에 대한 배송 정보를 입력합니다.\n출고일 처리가 안되어있으면 오늘 날짜를 기준으로 업데이트합니다.")
+    public ResponseEntity<List<DeliveryInfoResDto>> updateDeliveryInfo(@RequestBody List<DeliveryInfoReqDto> request) {
+        return ResponseEntity.ok().body(storeService.updateDeliveryInfo(request));
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
+++ b/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
@@ -1,6 +1,8 @@
 package com.rabbit.dayfilm.store.controller;
 
+import com.rabbit.dayfilm.common.CodeSet;
 import com.rabbit.dayfilm.common.EndPoint;
+import com.rabbit.dayfilm.common.response.SuccessResponse;
 import com.rabbit.dayfilm.store.dto.*;
 import com.rabbit.dayfilm.store.service.StoreService;
 import io.swagger.annotations.Api;
@@ -27,7 +29,7 @@ public class StoreController {
 
 
     @GetMapping(EndPoint.ORDER_LIST)
-    @Operation(summary = "주문 목록 조회", description = "파라미터로 보내는 상태, 수령 방법 등에 따라서 동적인 검색 결과를 반환.")
+    @Operation(summary = "주문 목록 조회", description = "파라미터로 보내는 상태, 수령 방법 등에 따라서 동적인 검색 결과를 반환.\nisCanceled는 필수값입니다. 환불 여부입니다.\nisCanceled에 따라서 status가 결정되므로 null로 보내주시면 됩니다.")
     public ResponseEntity<OrderListInStoreResDto> getOrderList(@ModelAttribute OrderListCond condition, Pageable pageable) {
         return ResponseEntity.ok(storeService.getOrderList(condition, pageable));
     }
@@ -48,5 +50,12 @@ public class StoreController {
     @Operation(summary = "반납 완료 처리", description = "")
     public ResponseEntity<OrderPkDto> doneOrder(@RequestBody OrderPkDto request) {
         return ResponseEntity.ok().body(storeService.doneOrder(request));
+    }
+
+    @PostMapping(EndPoint.ITEM_CANCEL_PROCESS)
+    @Operation(summary = "환불 접수", description = "주문번호와 승인여부를 리스트로 받아서 처리합니다.\n승인할 경우 환불 처리 상태로 바꾸고, 거절할 경우 이전 상태로 돌아갑니다.\n잘못된 주문번호가 넘어오면 예외가 발생하고 전체 적용되지 않습니다.")
+    public ResponseEntity<SuccessResponse> processCancelOrder(@RequestBody List<ProcessCancelOrderDto> request) {
+        storeService.processCancelOrder(request);
+        return ResponseEntity.ok().body(new SuccessResponse(CodeSet.OK));
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
+++ b/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
@@ -3,6 +3,7 @@ package com.rabbit.dayfilm.store.controller;
 import com.rabbit.dayfilm.common.CodeSet;
 import com.rabbit.dayfilm.common.EndPoint;
 import com.rabbit.dayfilm.common.response.SuccessResponse;
+import com.rabbit.dayfilm.payment.dto.PaymentCancelResDto;
 import com.rabbit.dayfilm.store.dto.*;
 import com.rabbit.dayfilm.store.service.StoreService;
 import io.swagger.annotations.Api;
@@ -57,5 +58,11 @@ public class StoreController {
     public ResponseEntity<SuccessResponse> processCancelOrder(@RequestBody List<ProcessCancelOrderDto> request) {
         storeService.processCancelOrder(request);
         return ResponseEntity.ok().body(new SuccessResponse(CodeSet.OK));
+    }
+
+    @PostMapping(EndPoint.ITEM_CANCEL_FINISH)
+    @Operation(summary = "환불 진행", description = "각 주문별 환불이 된 뒤, 리스트로 반환합니다.")
+    public ResponseEntity<List<PaymentCancelResDto>> finishCancelOrder(@RequestBody FinishCancelOrderDto request) {
+        return ResponseEntity.ok().body(storeService.finishCancelOrder(request));
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
+++ b/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
@@ -3,6 +3,7 @@ package com.rabbit.dayfilm.store.controller;
 import com.rabbit.dayfilm.common.EndPoint;
 import com.rabbit.dayfilm.store.dto.*;
 import com.rabbit.dayfilm.store.service.StoreService;
+import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +14,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Api(tags = "가게")
 @RequestMapping(EndPoint.STORE)
 public class StoreController {
     private final StoreService storeService;

--- a/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
+++ b/src/main/java/com/rabbit/dayfilm/store/controller/StoreController.java
@@ -41,4 +41,10 @@ public class StoreController {
     public ResponseEntity<List<DeliveryInfoResDto>> updateDeliveryInfo(@RequestBody List<DeliveryInfoReqDto> request) {
         return ResponseEntity.ok().body(storeService.updateDeliveryInfo(request));
     }
+
+    @PostMapping(EndPoint.ORDER_DONE)
+    @Operation(summary = "반납 완료 처리", description = "")
+    public ResponseEntity<OrderPkDto> doneOrder(@RequestBody OrderPkDto request) {
+        return ResponseEntity.ok().body(storeService.doneOrder(request));
+    }
 }

--- a/src/main/java/com/rabbit/dayfilm/store/dto/DeliveryInfoReqDto.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/DeliveryInfoReqDto.java
@@ -1,0 +1,17 @@
+package com.rabbit.dayfilm.store.dto;
+
+import com.rabbit.dayfilm.order.entity.DeliveryCode;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeliveryInfoReqDto {
+    @ApiModelProperty(value="주문 PK(!= orderId)", example="1", required = true)
+    private Long orderPk;
+    @ApiModelProperty(value="택배회사 코드(노션 참고)", example="CUPOST", required = true)
+    private DeliveryCode deliveryCompany;
+    @ApiModelProperty(value="운송장 번호", example="12345", required = true)
+    private String trackingNumber;
+}

--- a/src/main/java/com/rabbit/dayfilm/store/dto/DeliveryInfoReqDto.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/DeliveryInfoReqDto.java
@@ -1,6 +1,6 @@
 package com.rabbit.dayfilm.store.dto;
 
-import com.rabbit.dayfilm.order.entity.DeliveryCode;
+import com.rabbit.dayfilm.delivery.dto.DeliveryCode;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,8 +10,10 @@ import lombok.Getter;
 public class DeliveryInfoReqDto {
     @ApiModelProperty(value="주문 PK(!= orderId)", example="1", required = true)
     private Long orderPk;
+
     @ApiModelProperty(value="택배회사 코드(노션 참고)", example="CUPOST", required = true)
     private DeliveryCode deliveryCompany;
+
     @ApiModelProperty(value="운송장 번호", example="12345", required = true)
     private String trackingNumber;
 }

--- a/src/main/java/com/rabbit/dayfilm/store/dto/DeliveryInfoResDto.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/DeliveryInfoResDto.java
@@ -1,0 +1,23 @@
+package com.rabbit.dayfilm.store.dto;
+
+import com.rabbit.dayfilm.order.entity.DeliveryCode;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class DeliveryInfoResDto {
+    @ApiModelProperty(value="주문 PK(!= orderId)", example="1", required = true)
+    private Long orderPk;
+    @ApiModelProperty(value="택배회사 코드(노션 참고)", example="CUPOST", required = true)
+    private DeliveryCode deliveryCompany;
+    @ApiModelProperty(value="운송장 번호", example="12345", required = true)
+    private String trackingNumber;
+    @ApiModelProperty(value="출고일", example="2023-03-28", required = true)
+    private LocalDate outgoingDate;
+}

--- a/src/main/java/com/rabbit/dayfilm/store/dto/DeliveryInfoResDto.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/DeliveryInfoResDto.java
@@ -1,6 +1,6 @@
 package com.rabbit.dayfilm.store.dto;
 
-import com.rabbit.dayfilm.order.entity.DeliveryCode;
+import com.rabbit.dayfilm.delivery.dto.DeliveryCode;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,10 +14,13 @@ import java.time.LocalDate;
 public class DeliveryInfoResDto {
     @ApiModelProperty(value="주문 PK(!= orderId)", example="1", required = true)
     private Long orderPk;
+
     @ApiModelProperty(value="택배회사 코드(노션 참고)", example="CUPOST", required = true)
     private DeliveryCode deliveryCompany;
+
     @ApiModelProperty(value="운송장 번호", example="12345", required = true)
     private String trackingNumber;
+
     @ApiModelProperty(value="출고일", example="2023-03-28", required = true)
     private LocalDate outgoingDate;
 }

--- a/src/main/java/com/rabbit/dayfilm/store/dto/FinishCancelOrderDto.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/FinishCancelOrderDto.java
@@ -1,0 +1,19 @@
+package com.rabbit.dayfilm.store.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FinishCancelOrderDto {
+    @ApiModelProperty(value="주문 번호", example="2023030901831", required = true)
+    private String orderId;
+
+    @ApiModelProperty(value="주문 번호의 PK", example="[1,2,3,4,5]", required = true)
+    private List<Long> orderPk;
+}

--- a/src/main/java/com/rabbit/dayfilm/store/dto/OrderListCond.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/OrderListCond.java
@@ -6,13 +6,15 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @AllArgsConstructor
 public class OrderListCond {
     @ApiModelProperty(value="가게 번호", example="4")
     private Long storeId;
     @ApiModelProperty(value="주문 상태", example="DELIVERY")
-    private OrderStatus status;
+    private List<OrderStatus> status;
     @ApiModelProperty(value="배송 방법", example="PARCEL")
     private DeliveryMethod method;
 }

--- a/src/main/java/com/rabbit/dayfilm/store/dto/OrderListCond.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/OrderListCond.java
@@ -2,6 +2,7 @@ package com.rabbit.dayfilm.store.dto;
 
 import com.rabbit.dayfilm.item.entity.DeliveryMethod;
 import com.rabbit.dayfilm.order.entity.OrderStatus;
+import com.sun.istack.NotNull;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,4 +18,10 @@ public class OrderListCond {
     private List<OrderStatus> status;
     @ApiModelProperty(value="배송 방법", example="PARCEL")
     private DeliveryMethod method;
+    @NotNull
+    private Boolean isCanceled;
+
+    public void setStatus(List<OrderStatus> status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/rabbit/dayfilm/store/dto/OrderListInStoreResDto.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/OrderListInStoreResDto.java
@@ -55,7 +55,7 @@ public class OrderListInStoreResDto {
             this.title = title;
             this.name = name;
             this.price = price;
-            this.parcelCompany = deliveryCode != null ? deliveryCode.getTitle() : null;
+            this.parcelCompany = deliveryCode != null ? deliveryCode.getName() : null;
             this.trackingNumber = trackingNumber;
             this.outgoingDate = outgoingDate;
             this.deliveryMethod = deliveryMethod;

--- a/src/main/java/com/rabbit/dayfilm/store/dto/OrderListInStoreResDto.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/OrderListInStoreResDto.java
@@ -2,7 +2,7 @@ package com.rabbit.dayfilm.store.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 import com.rabbit.dayfilm.item.entity.DeliveryMethod;
-import com.rabbit.dayfilm.order.entity.DeliveryCode;
+import com.rabbit.dayfilm.delivery.dto.DeliveryCode;
 import com.rabbit.dayfilm.order.entity.OrderStatus;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
@@ -25,20 +25,28 @@ public class OrderListInStoreResDto {
     public static class OrderList {
         @ApiModelProperty(value="주문 PK(상태 업데이트할 때 넘겨야 할 파라미터)", example="15")
         private Long id;
+
         @ApiModelProperty(value="주문 상태", example="PAY_DONE")
         private OrderStatus status;
+
         @ApiModelProperty(value="주문 번호(여러 상품을 한 번에 주문하면 타 상품과 중복 가능)", example="202303023971983")
         private String orderId;
+
         @ApiModelProperty(value="상품 이름", example="캐논 카메라")
         private String title;
+
         @ApiModelProperty(value="주문자 닉네임", example="박찬호")
         private String name;
+
         @ApiModelProperty(value="가격", example="2500")
         private Integer price;
+
         @ApiModelProperty(value="택배사", example="${미정}")
         private String parcelCompany;
+
         @ApiModelProperty(value="운송장 번호", example="234567")
         private String trackingNumber;
+
         @ApiModelProperty(value="출고 예정일", example="2023-03-24")
         private LocalDate outgoingDate;
 

--- a/src/main/java/com/rabbit/dayfilm/store/dto/OrderPkDto.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/OrderPkDto.java
@@ -1,0 +1,14 @@
+package com.rabbit.dayfilm.store.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderPkDto {
+    private List<Long> orderPk;
+}

--- a/src/main/java/com/rabbit/dayfilm/store/dto/ProcessCancelOrderDto.java
+++ b/src/main/java/com/rabbit/dayfilm/store/dto/ProcessCancelOrderDto.java
@@ -1,0 +1,13 @@
+package com.rabbit.dayfilm.store.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+@Getter
+public class ProcessCancelOrderDto {
+    @ApiModelProperty(value="주문 번호(PK)", example="1")
+    private Long orderPk;
+
+    @ApiModelProperty(value="환불 승인 여부", example="true")
+    private Boolean isAllow;
+}

--- a/src/main/java/com/rabbit/dayfilm/store/repository/StoreQueryRepositoryImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/store/repository/StoreQueryRepositoryImpl.java
@@ -93,8 +93,8 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 
-    private BooleanExpression eqStatus(OrderStatus status) {
-        return status != null ? order.status.eq(status) : null;
+    private BooleanExpression eqStatus(List<OrderStatus> status) {
+        return status != null ? order.status.in(status) : null;
     }
 
     private BooleanExpression eqMethod(DeliveryMethod method) {

--- a/src/main/java/com/rabbit/dayfilm/store/service/StoreService.java
+++ b/src/main/java/com/rabbit/dayfilm/store/service/StoreService.java
@@ -1,9 +1,6 @@
 package com.rabbit.dayfilm.store.service;
 
-import com.rabbit.dayfilm.store.dto.OrderCheckDto;
-import com.rabbit.dayfilm.store.dto.OrderCountResDto;
-import com.rabbit.dayfilm.store.dto.OrderListCond;
-import com.rabbit.dayfilm.store.dto.OrderListInStoreResDto;
+import com.rabbit.dayfilm.store.dto.*;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -12,4 +9,5 @@ public interface StoreService {
     OrderCountResDto getOrderCount(Long id);
     OrderListInStoreResDto getOrderList(OrderListCond condition, Pageable pageable);
     List<OrderCheckDto> checkOrders(List<OrderCheckDto> request);
+    List<DeliveryInfoResDto> updateDeliveryInfo(List<DeliveryInfoReqDto> request);
 }

--- a/src/main/java/com/rabbit/dayfilm/store/service/StoreService.java
+++ b/src/main/java/com/rabbit/dayfilm/store/service/StoreService.java
@@ -1,5 +1,6 @@
 package com.rabbit.dayfilm.store.service;
 
+import com.rabbit.dayfilm.payment.dto.PaymentCancelResDto;
 import com.rabbit.dayfilm.store.dto.*;
 import org.springframework.data.domain.Pageable;
 
@@ -12,4 +13,5 @@ public interface StoreService {
     List<DeliveryInfoResDto> updateDeliveryInfo(List<DeliveryInfoReqDto> request);
     OrderPkDto doneOrder(OrderPkDto request);
     void processCancelOrder(List<ProcessCancelOrderDto> request);
+    List<PaymentCancelResDto> finishCancelOrder(FinishCancelOrderDto request);
 }

--- a/src/main/java/com/rabbit/dayfilm/store/service/StoreService.java
+++ b/src/main/java/com/rabbit/dayfilm/store/service/StoreService.java
@@ -10,4 +10,5 @@ public interface StoreService {
     OrderListInStoreResDto getOrderList(OrderListCond condition, Pageable pageable);
     List<OrderCheckDto> checkOrders(List<OrderCheckDto> request);
     List<DeliveryInfoResDto> updateDeliveryInfo(List<DeliveryInfoReqDto> request);
+    OrderPkDto doneOrder(OrderPkDto request);
 }

--- a/src/main/java/com/rabbit/dayfilm/store/service/StoreService.java
+++ b/src/main/java/com/rabbit/dayfilm/store/service/StoreService.java
@@ -11,4 +11,5 @@ public interface StoreService {
     List<OrderCheckDto> checkOrders(List<OrderCheckDto> request);
     List<DeliveryInfoResDto> updateDeliveryInfo(List<DeliveryInfoReqDto> request);
     OrderPkDto doneOrder(OrderPkDto request);
+    void processCancelOrder(List<ProcessCancelOrderDto> request);
 }

--- a/src/main/java/com/rabbit/dayfilm/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/store/service/StoreServiceImpl.java
@@ -86,7 +86,7 @@ public class StoreServiceImpl implements StoreService {
 
             if (order.getOutgoingDate() == null) order.updateOutgoingDate(LocalDate.now());
 
-            order.setDelivery(new OrderDelivery(order, dto.getDeliveryCompany(), dto.getTrackingNumber()));
+            order.setOrderDelivery(new OrderDelivery(order, dto.getDeliveryCompany(), dto.getTrackingNumber()));
             response.add(new DeliveryInfoResDto(order.getId(), dto.getDeliveryCompany(), dto.getTrackingNumber(), order.getOutgoingDate()));
         }
 

--- a/src/main/java/com/rabbit/dayfilm/user/controller/UserController.java
+++ b/src/main/java/com/rabbit/dayfilm/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.rabbit.dayfilm.user.controller;
 import com.rabbit.dayfilm.common.CodeSet;
 import com.rabbit.dayfilm.user.dto.AddressCreateDto;
 import com.rabbit.dayfilm.user.dto.AddressDto;
+import com.rabbit.dayfilm.user.dto.CancelOrderDto;
 import com.rabbit.dayfilm.user.dto.OrderListResDto;
 import com.rabbit.dayfilm.user.service.UserAddressService;
 import com.rabbit.dayfilm.user.service.UserService;
@@ -56,6 +57,12 @@ public class UserController {
     public ResponseEntity<OrderListResDto> getOrderList(@RequestParam("userId") Long userId,
                                                         @RequestParam("isCanceled") Boolean isCanceled,
                                                         Pageable pageable) {
-        return ResponseEntity.ok(userService.getOrderList(userId, isCanceled, pageable));
+        return ResponseEntity.ok().body(userService.getOrderList(userId, isCanceled, pageable));
+    }
+
+    @PostMapping(EndPoint.ITEM_CANCEL)
+    @Operation(summary = "회원 환불 신청", description = "주문의 PK와 취소 사유를 보내주시면 됩니다.\n결제 전 주문이라면 주문을 삭제하고 장바구니로 옮깁니다.")
+    public ResponseEntity<SuccessResponse> requestCancelOrder(@RequestBody CancelOrderDto request) {
+        return ResponseEntity.ok().body(new SuccessResponse(userService.requestCancelOrder(request)));
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/user/dto/CancelOrderDto.java
+++ b/src/main/java/com/rabbit/dayfilm/user/dto/CancelOrderDto.java
@@ -1,5 +1,6 @@
 package com.rabbit.dayfilm.user.dto;
 
+import com.rabbit.dayfilm.payment.dto.RefundReceiveAccount;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,4 +13,7 @@ public class CancelOrderDto {
 
     @ApiModelProperty(value="환불 사유", example="물건 상태가 안좋아서.", required = true)
     private String cancelReason;
+
+    @ApiModelProperty(value="가상 계좌 결제의 경우 환불 받을 정보", example="{--}")
+    private RefundReceiveAccount virtualRefundInfo;
 }

--- a/src/main/java/com/rabbit/dayfilm/user/dto/CancelOrderDto.java
+++ b/src/main/java/com/rabbit/dayfilm/user/dto/CancelOrderDto.java
@@ -1,0 +1,15 @@
+package com.rabbit.dayfilm.user.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CancelOrderDto {
+    @ApiModelProperty(value="주문 번호(PK)", example="1", required = true)
+    private Long orderPk;
+
+    @ApiModelProperty(value="환불 사유", example="물건 상태가 안좋아서.", required = true)
+    private String cancelReason;
+}

--- a/src/main/java/com/rabbit/dayfilm/user/dto/OrderListResDto.java
+++ b/src/main/java/com/rabbit/dayfilm/user/dto/OrderListResDto.java
@@ -2,6 +2,7 @@ package com.rabbit.dayfilm.user.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 import com.rabbit.dayfilm.order.entity.OrderStatus;
+import com.rabbit.dayfilm.payment.toss.object.Method;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -27,6 +28,8 @@ public class OrderListResDto {
         @ApiModelProperty(value="주문번호(PK)", example="11")
         private Long orderPk;
 
+        private String orderId;
+
         @ApiModelProperty(value="아이템 제목", example="캐논 카메라")
         private String title;
 
@@ -48,18 +51,22 @@ public class OrderListResDto {
         @ApiModelProperty(value="가격", example="25000")
         private Integer price;
 
+        private Method payMethod;
+
         @QueryProjection
         public OrderList(Long orderPk, String title, String imagePath,
-                         LocalDateTime created, LocalDateTime started, LocalDateTime ended,
-                         OrderStatus status, Integer price) {
+                         LocalDateTime created, LocalDateTime started, LocalDateTime ended, String orderId,
+                         OrderStatus status, Integer price, String payMethod) {
             this.orderPk = orderPk;
             this.title = title;
             this.imagePath = imagePath;
             this.created = created;
             this.ended = ended;
+            this.orderId = orderId;
             this.started = started;
             this.status = status;
             this.price = price;
+            this.payMethod = Method.findMethod(payMethod);
         }
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/user/dto/OrderListResDto.java
+++ b/src/main/java/com/rabbit/dayfilm/user/dto/OrderListResDto.java
@@ -15,31 +15,44 @@ import java.util.List;
 public class OrderListResDto {
     @ApiModelProperty(value="전체 페이지 수", example="15")
     private Integer totalPage;
+
     @ApiModelProperty(value="마지막 페이지 여부", example="true")
     private Boolean isLast;
+
     private List<OrderList> contents;
 
     @Getter
     @NoArgsConstructor
     public static class OrderList {
+        @ApiModelProperty(value="주문번호(PK)", example="11")
+        private Long orderPk;
+
         @ApiModelProperty(value="아이템 제목", example="캐논 카메라")
         private String title;
+
         @ApiModelProperty(value="아이템 썸네일 경로", example="https://s3.~")
         private String imagePath;
+
         @ApiModelProperty(value="주문 날짜", example="2023-03-15T23:11")
         private LocalDateTime created;
+
         @ApiModelProperty(value="대여 날짜", example="2023-03-16T23:00")
         private LocalDateTime started;
+
         @ApiModelProperty(value="반납 날짜", example="2023-03-20T23:00")
         private LocalDateTime ended;
+
         @ApiModelProperty(value="상태", example="PAY_WAITING")
         private OrderStatus status;
+
         @ApiModelProperty(value="가격", example="25000")
         private Integer price;
+
         @QueryProjection
-        public OrderList(String title, String imagePath,
-                               LocalDateTime created, LocalDateTime started, LocalDateTime ended,
-                               OrderStatus status, Integer price) {
+        public OrderList(Long orderPk, String title, String imagePath,
+                         LocalDateTime created, LocalDateTime started, LocalDateTime ended,
+                         OrderStatus status, Integer price) {
+            this.orderPk = orderPk;
             this.title = title;
             this.imagePath = imagePath;
             this.created = created;

--- a/src/main/java/com/rabbit/dayfilm/user/service/UserService.java
+++ b/src/main/java/com/rabbit/dayfilm/user/service/UserService.java
@@ -1,10 +1,12 @@
 package com.rabbit.dayfilm.user.service;
 
 import com.rabbit.dayfilm.common.CodeSet;
+import com.rabbit.dayfilm.user.dto.CancelOrderDto;
 import com.rabbit.dayfilm.user.dto.OrderListResDto;
 import org.springframework.data.domain.Pageable;
 
 public interface UserService {
     CodeSet checkNickname(String nickname);
     OrderListResDto getOrderList(Long userId, Boolean isCanceled, Pageable pageable);
+    CodeSet requestCancelOrder(CancelOrderDto request);
 }

--- a/src/main/java/com/rabbit/dayfilm/user/service/UserServiceImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/user/service/UserServiceImpl.java
@@ -63,7 +63,7 @@ public class UserServiceImpl implements UserService {
             orderRepository.delete(order);
             return CodeSet.DELETE_ORDER;
         } else {
-            orderReturnDeliveryRepository.save(new OrderReturnDelivery(order, request.getCancelReason()));
+            order.setReturnDelivery(new OrderReturnDelivery(order, request.getCancelReason(), order.getStatus()));
             order.updateStatus(OrderStatus.CANCEL_WAIT);
             return CodeSet.OK;
         }

--- a/src/main/java/com/rabbit/dayfilm/user/service/UserServiceImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/user/service/UserServiceImpl.java
@@ -1,19 +1,32 @@
 package com.rabbit.dayfilm.user.service;
 
+import com.rabbit.dayfilm.basket.entity.Basket;
+import com.rabbit.dayfilm.basket.repository.BasketRepository;
 import com.rabbit.dayfilm.common.CodeSet;
+import com.rabbit.dayfilm.exception.CustomException;
+import com.rabbit.dayfilm.item.repository.ProductRepository;
+import com.rabbit.dayfilm.order.entity.Order;
+import com.rabbit.dayfilm.order.entity.OrderReturnDelivery;
+import com.rabbit.dayfilm.order.entity.OrderStatus;
 import com.rabbit.dayfilm.order.repository.OrderRepository;
+import com.rabbit.dayfilm.order.repository.OrderReturnDeliveryRepository;
+import com.rabbit.dayfilm.user.dto.CancelOrderDto;
 import com.rabbit.dayfilm.user.dto.OrderListResDto;
 import com.rabbit.dayfilm.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final OrderRepository orderRepository;
+    private final OrderReturnDeliveryRepository orderReturnDeliveryRepository;
+    private final ProductRepository productRepository;
+    private final BasketRepository basketRepository;
 
     @Override
     public CodeSet checkNickname(String nickname) {
@@ -25,5 +38,34 @@ public class UserServiceImpl implements UserService {
     public OrderListResDto getOrderList(Long userId, Boolean isCanceled, Pageable pageable) {
         Page<OrderListResDto.OrderList> content = orderRepository.getOrderList(userId, isCanceled, pageable);
         return new OrderListResDto(content.getTotalPages(), content.isLast(), content.getContent());
+    }
+
+    @Override
+    @Transactional
+    public CodeSet requestCancelOrder(CancelOrderDto request) {
+        Order order = orderRepository.findById(request.getOrderPk()).orElseThrow(() -> new CustomException("주문이 존재하지 않습니다."));
+
+        if (order.getStatus() == OrderStatus.PAY_WAITING) {
+            productRepository.findById(order.getProductId())
+                    .ifPresent(product -> userRepository.findById(order.getUserId())
+                            .ifPresent(user ->
+                                    basketRepository.save(
+                                            Basket.builder()
+                                                    .user(user)
+                                                    .product(product)
+                                                    .started(order.getStarted())
+                                                    .ended(order.getEnded())
+                                                    .method(order.getMethod())
+                                                    .build()
+                                    )
+                            ));
+
+            orderRepository.delete(order);
+            return CodeSet.DELETE_ORDER;
+        } else {
+            orderReturnDeliveryRepository.save(new OrderReturnDelivery(order, request.getCancelReason()));
+            order.updateStatus(OrderStatus.CANCEL_WAIT);
+            return CodeSet.OK;
+        }
     }
 }

--- a/src/main/java/com/rabbit/dayfilm/user/service/UserServiceImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/user/service/UserServiceImpl.java
@@ -6,7 +6,7 @@ import com.rabbit.dayfilm.common.CodeSet;
 import com.rabbit.dayfilm.exception.CustomException;
 import com.rabbit.dayfilm.item.repository.ProductRepository;
 import com.rabbit.dayfilm.order.entity.Order;
-import com.rabbit.dayfilm.order.entity.OrderReturnDelivery;
+import com.rabbit.dayfilm.order.entity.OrderReturnInfo;
 import com.rabbit.dayfilm.order.entity.OrderStatus;
 import com.rabbit.dayfilm.order.repository.OrderRepository;
 import com.rabbit.dayfilm.payment.entity.PayInformation;
@@ -75,7 +75,7 @@ public class UserServiceImpl implements UserService {
             orderRepository.delete(order);
             return CodeSet.DELETE_ORDER;
         } else {
-            order.setReturnDelivery(new OrderReturnDelivery(order, request.getCancelReason(), order.getStatus()));
+            order.setReturnInfo(new OrderReturnInfo(order, request.getCancelReason(), order.getStatus()));
             order.updateStatus(OrderStatus.CANCEL_WAIT);
             return CodeSet.OK;
         }


### PR DESCRIPTION
- 비즈니스 로직에 맞게 회원-가게 간 환불 프로세스 구현
  - 각 단계에 따른 주문 상태 관리 및 부가적인 정보 저장(Ex.가상 계좌의 환불 정보, 환불 사유 등)
  - 프론트 협의 하 올바른 데이터만 반영 후 수정된 데이터 반환하는 로직 존재(가게의 환불 처리 과정)
  - 그 외에 예외 상황 발생 시 트랜잭션에 따라 롤백
- 오픈소스를 활용한 배송 추적 API 구현