### PR TITLE
FEAT: 배송 정보 캐싱

### DIFF
--- a/src/main/java/com/rabbit/dayfilm/auth/UserInfo.java
+++ b/src/main/java/com/rabbit/dayfilm/auth/UserInfo.java
@@ -24,12 +24,12 @@ public class UserInfo implements Serializable, UserDetails {
 
     @Id
     private String email;
+    private Long pk;
     private String pw;
     private String refreshToken;
     private String nickname;
     private Role role;
-//    @TimeToLive(unit = TimeUnit.DAYS)
-//    private Long ttl;
+
     public void changeRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }

--- a/src/main/java/com/rabbit/dayfilm/auth/dto/AuthResDto.java
+++ b/src/main/java/com/rabbit/dayfilm/auth/dto/AuthResDto.java
@@ -14,4 +14,12 @@ public class AuthResDto {
 
     @ApiModelProperty(value="권한\nUSER:일반 회원\nSTORE:가게\nSELLER:판매 권한을 받은 회원", example="USER")
     private Role role;
+
+    @ApiModelProperty(value="PK", example="1")
+    private Long pk;
+
+    public AuthResDto(String nickname, Role role) {
+        this.nickname = nickname;
+        this.role = role;
+    }
 }

--- a/src/main/java/com/rabbit/dayfilm/auth/filter/LoginFilter.java
+++ b/src/main/java/com/rabbit/dayfilm/auth/filter/LoginFilter.java
@@ -80,7 +80,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         response.setHeader("Refresh-Token", BEARER + refreshToken);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("utf-8");
-        response.getWriter().write(objectMapper.writeValueAsString(new AuthResDto(user.getNickname(), user.getRole())));
+        response.getWriter().write(objectMapper.writeValueAsString(new AuthResDto(user.getNickname(), user.getRole(), user.getPk())));
     }
 
     @Override

--- a/src/main/java/com/rabbit/dayfilm/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/auth/service/AuthServiceImpl.java
@@ -90,11 +90,12 @@ public class AuthServiceImpl implements UserDetailsService, AuthService {
                     .picturePath(imageInfoDto.getImagePath())
                     .build();
 
-            storeRepository.save(store);
+            Store savedStore = storeRepository.save(store);
             authRedisRepository.save(
                     UserInfo.builder()
-                            .email(store.getEmail())
-                            .pw(store.getPw())
+                            .email(savedStore.getEmail())
+                            .pw(savedStore.getPw())
+                            .pk(savedStore.getId())
                             .refreshToken(refreshToken)
                             .nickname(request.getStoreName())
                             .role(Role.STORE)
@@ -120,13 +121,14 @@ public class AuthServiceImpl implements UserDetailsService, AuthService {
                     .role(Role.USER)
                     .build();
 
-            userRepository.save(user);
+            User savedUser = userRepository.save(user);
             authRedisRepository.save(
                     UserInfo.builder()
-                            .email(user.getEmail())
-                            .pw(user.getPw())
+                            .email(savedUser.getEmail())
+                            .pw(request.getPw())
+                            .pk(savedUser.getId())
                             .refreshToken(refreshToken)
-                            .nickname(user.getNickname())
+                            .nickname(savedUser.getNickname())
                             .role(Role.USER)
                             .build()
             );

--- a/src/main/java/com/rabbit/dayfilm/delivery/dto/DeliveryStatus.java
+++ b/src/main/java/com/rabbit/dayfilm/delivery/dto/DeliveryStatus.java
@@ -15,7 +15,7 @@ public enum DeliveryStatus {
     @JsonCreator
     public static DeliveryStatus fromString(String status) {
         for (DeliveryStatus d : DeliveryStatus.values()) {
-            if (d.name().toLowerCase().equals(status))
+            if (d.name().equalsIgnoreCase(status))
                 return d;
         }
         throw new CustomException("배송 정보가 올바르지 않습니다.");

--- a/src/main/java/com/rabbit/dayfilm/delivery/dto/DeliveryTrackerDto.java
+++ b/src/main/java/com/rabbit/dayfilm/delivery/dto/DeliveryTrackerDto.java
@@ -2,40 +2,26 @@ package com.rabbit.dayfilm.delivery.dto;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.rabbit.dayfilm.common.serializer.OffsetToLocalDateTimeSerializer;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-public class DeliveryTracker {
+public class DeliveryTrackerDto {
     private FromToInfo from;
     private FromToInfo to;
     private TrackerState state;
     private List<TrackerProgress> progresses;
-
-    public DeliveryTracker(DeliveryTrackerDto dto) {
-        this.from = new FromToInfo(dto.getFrom().getName(), dto.getFrom().getTime());
-        this.to = new FromToInfo(dto.getTo().getName(), dto.getTo().getTime());
-        this.state = new TrackerState(dto.getState().getId(), dto.getState().getText());
-        this.progresses = new ArrayList<>();
-        for (DeliveryTrackerDto.TrackerProgress p : dto.getProgresses()) {
-            this.progresses.add(
-                    new TrackerProgress(
-                            p.getTime(),
-                            new TrackerLocation(p.getLocation().getName()),
-                            new TrackerStatus(p.getStatus().getId(), p.getStatus().getText()), p.getDescription()
-                    )
-            );
-        }
-    }
 
     @AllArgsConstructor
     @NoArgsConstructor
@@ -45,7 +31,7 @@ public class DeliveryTracker {
         private String name;
 
         @ApiModelProperty(value="시간(보낸시간or받은시간)", example="2023-03-28T23:01:00")
-        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+        @JsonDeserialize(using = OffsetToLocalDateTimeSerializer.class)
         @JsonSerialize(using = LocalDateTimeSerializer.class)
         private LocalDateTime time;
     }
@@ -66,7 +52,7 @@ public class DeliveryTracker {
     @Getter
     public static class TrackerProgress {
         @ApiModelProperty(value="시간", example="2023-03-28T23:01:00")
-        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+        @JsonDeserialize(using = OffsetToLocalDateTimeSerializer.class)
         @JsonSerialize(using = LocalDateTimeSerializer.class)
         private LocalDateTime time;
 

--- a/src/main/java/com/rabbit/dayfilm/delivery/dto/DeliveryTrackingDto.java
+++ b/src/main/java/com/rabbit/dayfilm/delivery/dto/DeliveryTrackingDto.java
@@ -1,17 +1,26 @@
 package com.rabbit.dayfilm.delivery.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
 
+import javax.persistence.Id;
 import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @NoArgsConstructor
+@RedisHash(value = "delivery", timeToLive = 3600)
 @Getter
 public class DeliveryTrackingDto {
+    @Id
+    private String trackingNumber;
     private DeliveryProductInfo productInfo;
     private DeliveryTracker tracker;
 
@@ -25,6 +34,8 @@ public class DeliveryTrackingDto {
         private String imagePath;
 
         @ApiModelProperty(value="주문 시간", example = "2023-03-28T12:00:23")
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
         private LocalDateTime orderDate;
 
         @QueryProjection

--- a/src/main/java/com/rabbit/dayfilm/delivery/service/DeliveryServiceImpl.java
+++ b/src/main/java/com/rabbit/dayfilm/delivery/service/DeliveryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.rabbit.dayfilm.delivery.service;
 
 import com.rabbit.dayfilm.delivery.dto.DeliveryTracker;
+import com.rabbit.dayfilm.delivery.dto.DeliveryTrackerDto;
 import com.rabbit.dayfilm.delivery.dto.DeliveryTrackingDto;
 import com.rabbit.dayfilm.exception.CustomException;
 import com.rabbit.dayfilm.delivery.dto.DeliveryCode;
@@ -8,6 +9,7 @@ import com.rabbit.dayfilm.order.entity.Order;
 import com.rabbit.dayfilm.order.entity.OrderStatus;
 import com.rabbit.dayfilm.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -15,6 +17,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 import javax.annotation.PostConstruct;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -31,13 +34,13 @@ public class DeliveryServiceImpl implements DeliveryService {
     }
 
     @Override
+    @Cacheable(value = "delivery", key="#trackingNumber", cacheManager = "cacheManager")
     public DeliveryTrackingDto tracking(Long orderPk, DeliveryCode code, String trackingNumber) {
         Order order = orderRepository.findById(orderPk).orElseThrow(() -> new CustomException("주문이 존재하지 않습니다."));
         if (!(order.getStatus() == OrderStatus.DELIVERY || order.getStatus() == OrderStatus.RETURN_DELIVERY))
             throw new CustomException("배송 중인 주문이 아닙니다.");
 
-
-        DeliveryTracker tracker = webClient.get()
+        DeliveryTrackerDto tracker = webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/{carrierId}/tracks/{trackId}")
                         .build(code.getId(), trackingNumber)
@@ -45,10 +48,12 @@ public class DeliveryServiceImpl implements DeliveryService {
                 .retrieve()
                 .onStatus(HttpStatus::is4xxClientError, res -> Mono.error(new CustomException("배송 정보가 올바르지 않습니다.")))
                 .onStatus(HttpStatus::is5xxServerError, res -> Mono.error(new CustomException("배송 정보를 추적할 수 없습니다.")))
-                .bodyToMono(DeliveryTracker.class)
+                .bodyToMono(DeliveryTrackerDto.class)
                 .block();
 
+        Objects.requireNonNull(tracker, "배송 정보가 존재하지 않습니다.");
+
         DeliveryTrackingDto.DeliveryProductInfo productInfo = orderRepository.getProductDeliveryInfo(orderPk);
-        return new DeliveryTrackingDto(productInfo, tracker);
+        return new DeliveryTrackingDto(trackingNumber, productInfo, new DeliveryTracker(tracker));
     }
 }


### PR DESCRIPTION
- 사용하는 라이브러리와 싱크를 맞추기 위해, 운송장 번호에 따라 1시간 캐싱
- 라이브러리, 서버, 클라이언트 간 LocalDateTime, OffsetDateTime 직렬화가 안맞아서 각각의 Serializer를 가진 DTO 생성
- PK 관련 로그인, 회원가입 수정 커밋 반영